### PR TITLE
fix: retrieve upload after create

### DIFF
--- a/packages/api/src/utils/db-client.js
+++ b/packages/api/src/utils/db-client.js
@@ -86,7 +86,7 @@ export class DBClient {
       throw new DBError(rsp.error)
     }
 
-    const upload = await this.getUpload(data.content_cid, data.user_id)
+    const upload = await this.getUpload(data.source_cid, data.user_id)
     if (upload) {
       return upload
     }

--- a/packages/api/test/scripts/helpers.js
+++ b/packages/api/test/scripts/helpers.js
@@ -12,7 +12,7 @@ export async function clearStores() {
 
 export const rawClient = new PostgrestClient(DATABASE_URL, {
   headers: {
-    apikey: DATABASE_TOKEN,
+    Authorization: `Bearer ${DATABASE_TOKEN}`,
   },
 })
 
@@ -77,7 +77,7 @@ export class DBTestClient {
    * @param {{ cid: string; name: string; }} data
    */
   async addPin(data) {
-    await fetch('/v1/pins', {
+    const res = await fetch('/v1/pins', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${this.token}`,
@@ -88,6 +88,9 @@ export class DBTestClient {
         name: data.name,
       }),
     })
+    if (!res.ok) {
+      throw new Error(`Failed to add pin: ${await res.text()}`)
+    }
   }
 }
 /**


### PR DESCRIPTION
`getUpload` takes the source CID not the normalized content CID. For some uploads this will have failed.