### PR TITLE
fix: add CORS headers to /version endpoint

### DIFF
--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -76,7 +76,7 @@ r.add('get', '/version', (event) => {
     branch: BRANCH,
     mode: getMaintenanceMode(),
   })
-})
+}, [postCors])
 
 // Remote Pinning API
 


### PR DESCRIPTION
Adds CORS headers to `/version` so that it can be called from the browser.