### PR TITLE
fix: temporarily revert engines restriction

### DIFF
--- a/packages/niftysave/package.json
+++ b/packages/niftysave/package.json
@@ -66,8 +66,5 @@
   "homepage": "https://github.com/nftstorage/niftysave#readme",
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=16.10.0"
   }
 }


### PR DESCRIPTION
It turns out there are a lot of github workflows that are still npm installing in the root with Node.js 14. Lets open an issue to get this re-added when we have time to fix them all.