### PR TITLE
fix: throw an error for missing env vars

### DIFF
--- a/packages/api/pw-test.config.cjs
+++ b/packages/api/pw-test.config.cjs
@@ -54,11 +54,12 @@ module.exports = {
     if (
       stdout.toString().includes('Server started on: http://localhost:9094')
     ) {
-      console.log('⚡️ Mock cluster started.')
+      console.log('⚡️ Mock IPFS Cluster started.')
       await execa(cli, ['db', '--start', '--project', project])
+      console.log('⚡️ Postgres started.')
       await execa(cli, ['db-sql', '--cargo', '--testing'])
+      console.log('⚡️ SQL schema loaded.')
 
-      console.log('⚡️ Mock postgres started.')
       proc.stdout.on('data', (line) => console.log(line.toString()))
       return { proc, project }
     }

--- a/packages/api/scripts/cmds/db-sql.js
+++ b/packages/api/scripts/cmds/db-sql.js
@@ -11,6 +11,19 @@ const { Client } = pg
  * @param {{ reset?: boolean; cargo?: boolean; testing?: boolean; }} opts
  */
 export async function dbSqlCmd(opts) {
+  // Check required env vars are present
+  ;[
+    'DAG_CARGO_HOST',
+    'DAG_CARGO_DATABASE',
+    'DAG_CARGO_USER',
+    'DAG_CARGO_PASSWORD',
+    'DATABASE_CONNECTION',
+  ].forEach((v) => {
+    if (!process.env[v]) {
+      throw new Error(`missing environment variable ${v}`)
+    }
+  })
+
   // read all the SQL files
   const tables = fs.readFileSync(path.join(__dirname, '../../db/tables.sql'), {
     encoding: 'utf-8',


### PR DESCRIPTION
I was missing these variables and it was hanging for a long time because of the client connection retry. Validating the required env vars gives quick feedback.