### PR TITLE
fix: do not allow delete of deleted NFT

### DIFF
--- a/packages/api/src/utils/db-client.js
+++ b/packages/api/src/utils/db-client.js
@@ -220,6 +220,7 @@ export class DBClient {
         updated_at: date,
       })
       .match({ source_cid: cid, user_id: userId })
+      .filter('deleted_at', 'is', null)
       .single()
 
     if (status === 406 || !data) {


### PR DESCRIPTION
Additional check to ensure the NFT being deleted is not already deleted. This ensures the `deleted_at` timestamp cannot be updated after deletion.