### PR TITLE
Chore: rerun Niftsave

### DIFF
--- a/packages/niftysave/src/ingest.js
+++ b/packages/niftysave/src/ingest.js
@@ -6,7 +6,7 @@ import { fetchNextNFTBatch, writeScrapedRecord } from './ingest/repo.js'
 
 import { TransformStream } from './stream.js'
 import { configure } from './config.js'
-import { intializeCursor } from './ingest/cursor.js'
+// import { intializeCursor } from './ingest/cursor.js'
 import { script } from 'subprogram'
 import { setTimeout as sleep } from './timers.js'
 
@@ -67,7 +67,8 @@ async function spawn(config) {
  */
 async function readIntoInbox(config, writeable) {
   const writer = writeable.getWriter()
-  let cursor = await intializeCursor(config)
+  //let cursor = await intializeCursor(config)
+  let cursor = ''
   while (true) {
     let scrape = []
     try {


### PR DESCRIPTION
This PR just restarts Niftysave from the beginning. The goal is to see if the nft count changes. Existing items will be skipped, however if anything that was missed is caught - it will be added.

This simply 'resets' the cursor to do this.