### PR TITLE
refactor: get DB client from route context

### DIFF
--- a/packages/api/src/bindings.d.ts
+++ b/packages/api/src/bindings.d.ts
@@ -2,6 +2,7 @@ export {}
 
 import Toucan from 'toucan-js'
 import { Mode } from './middleware/maintenance.js'
+import { DBClient } from './utils/db-client.js'
 
 declare global {
   const SALT: string
@@ -35,7 +36,10 @@ declare global {
 export interface RouteContext {
   sentry: Toucan
   params: Record<string, string>
+  db: DBClient
 }
+
+export type Handler = (event: FetchEvent, ctx: RouteContext) => Promise<Response> | Response
 
 export interface Pin {
   /**

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -46,6 +46,7 @@ import {
 } from './middleware/maintenance.js'
 import { withPsaErrorHandler } from './middleware/psa.js'
 import { cluster } from './constants.js'
+import { getContext } from './utils/context.js'
 
 const log = debug('router')
 
@@ -53,7 +54,7 @@ const getMaintenanceMode = () =>
   typeof MAINTENANCE_MODE !== 'undefined' ? MAINTENANCE_MODE : DEFAULT_MODE
 setMaintenanceModeGetter(getMaintenanceMode)
 
-const r = new Router({
+const r = new Router(getContext, {
   onError(req, err, { sentry }) {
     log(err)
     return HTTPError.respond(err, { sentry })
@@ -90,9 +91,9 @@ r.add(
 
 /**
  * Apply Pinning Services API Middleware
- * @param {import('./utils/router.js').Handler} handler
+ * @param {import('./utils/router.js').Handler<import('./bindings.js').RouteContext>} handler
  * @param {import('./middleware/maintenance').Mode} mode
- * @returns {import('./utils/router.js').Handler}
+ * @returns {import('./utils/router.js').Handler<import('./bindings.js').RouteContext>}
  */
 const psa = (handler, mode) => withPsaErrorHandler(withMode(handler, mode))
 

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -91,9 +91,9 @@ r.add(
 
 /**
  * Apply Pinning Services API Middleware
- * @param {import('./utils/router.js').Handler<import('./bindings.js').RouteContext>} handler
+ * @param {import('./bindings').Handler} handler
  * @param {import('./middleware/maintenance').Mode} mode
- * @returns {import('./utils/router.js').Handler<import('./bindings.js').RouteContext>}
+ * @returns {import('./bindings').Handler}
  */
 const psa = (handler, mode) => withPsaErrorHandler(withMode(handler, mode))
 

--- a/packages/api/src/middleware/maintenance.js
+++ b/packages/api/src/middleware/maintenance.js
@@ -2,7 +2,7 @@ import { HTTPError } from '../errors.js'
 
 /**
  * @typedef {'rw' | 'r-' | '--'} Mode
- * @typedef {import('../utils/router.js').Handler} Handler
+ * @typedef {import('../bindings').Handler} Handler
  */
 
 /**

--- a/packages/api/src/middleware/psa.js
+++ b/packages/api/src/middleware/psa.js
@@ -5,7 +5,7 @@ import { JSONResponse } from '../utils/json-response.js'
  * Catch an error and respond with a response as required by the PSA spec,
  * logging the actual error with sentry.
  *
- * @typedef {import('../utils/router.js').Handler} Handler
+ * @typedef {import('../bindings').Handler} Handler
  * @param {Handler} handler
  * @returns {Handler}
  */

--- a/packages/api/src/routes-v1/login.js
+++ b/packages/api/src/routes-v1/login.js
@@ -1,10 +1,10 @@
 import { JSONResponse } from '../utils/json-response.js'
 import { loginOrRegister } from '../utils/auth-v1.js'
 
-/** @type {import('../utils/router').Handler} */
-export async function loginV1(event) {
+/** @type {import('../bindings').Handler} */
+export async function loginV1(event, ctx) {
   const data = await event.request.json()
-  const auth = await loginOrRegister(event, data)
+  const auth = await loginOrRegister(event, ctx, data)
   return new JSONResponse({
     ok: true,
     value: auth,

--- a/packages/api/src/routes-v1/nfts-check.js
+++ b/packages/api/src/routes-v1/nfts-check.js
@@ -1,14 +1,10 @@
 import { JSONResponse } from '../utils/json-response.js'
 import { HTTPError } from '../errors.js'
-import { secrets, database } from '../constants.js'
-import { DBClient } from '../utils/db-client'
 import { parseCid } from '../utils/utils.js'
 import { toCheckNftResponse } from '../utils/db-transforms.js'
 
-const db = new DBClient(database.url, secrets.database)
-
-/** @type {import('../utils/router.js').Handler} */
-export const checkV1 = async (event, { params }) => {
+/** @type {import('../bindings').Handler} */
+export const checkV1 = async (event, { params, db }) => {
   const cid = parseCid(params.cid)
   const content = await db.getContent(cid.contentCid)
 

--- a/packages/api/src/routes-v1/nfts-delete.js
+++ b/packages/api/src/routes-v1/nfts-delete.js
@@ -3,13 +3,13 @@ import { validate } from '../utils/auth-v1.js'
 import { JSONResponse } from '../utils/json-response.js'
 import { parseCid } from '../utils/utils.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export const nftDeleteV1 = async (event, ctx) => {
-  const { db, user } = await validate(event, ctx)
+  const { user } = await validate(event, ctx)
   const { params } = ctx
   const cid = parseCid(params.cid)
 
-  const data = await db.deleteUpload(cid.sourceCid, user.id)
+  const data = await ctx.db.deleteUpload(cid.sourceCid, user.id)
 
   if (data) {
     return new JSONResponse(

--- a/packages/api/src/routes-v1/nfts-get.js
+++ b/packages/api/src/routes-v1/nfts-get.js
@@ -8,12 +8,12 @@ import { toNFTResponse } from '../utils/db-transforms.js'
  * @typedef {import('../bindings').Deal} Deal
  */
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export const statusV1 = async (event, ctx) => {
   const { params } = ctx
-  const { user, db } = await validate(event, ctx)
+  const { user } = await validate(event, ctx)
   const cid = parseCid(params.cid)
-  const nft = await db.getUpload(cid.sourceCid, user.id)
+  const nft = await ctx.db.getUpload(cid.sourceCid, user.id)
   if (nft) {
     return new JSONResponse({
       ok: true,

--- a/packages/api/src/routes-v1/nfts-list.js
+++ b/packages/api/src/routes-v1/nfts-list.js
@@ -16,9 +16,9 @@ const validator = new Validator({
   },
 })
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function nftListV1(event, ctx) {
-  const { user, db } = await validate(event, ctx)
+  const { user } = await validate(event, ctx)
   const { searchParams } = new URL(event.request.url)
   const options = {
     limit: searchParams.get('limit')
@@ -32,7 +32,7 @@ export async function nftListV1(event, ctx) {
     throw new HTTPError('invalid params', 400)
   }
 
-  const nfts = await db.listUploads(user.id, options)
+  const nfts = await ctx.db.listUploads(user.id, options)
 
   return new JSONResponse({
     ok: true,

--- a/packages/api/src/routes-v1/nfts-store.js
+++ b/packages/api/src/routes-v1/nfts-store.js
@@ -16,9 +16,9 @@ const log = debug('nft-store')
  * @typedef {import('../bindings').NFT} NFT
  */
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function nftStoreV1(event, ctx) {
-  const { user, key, db } = await validate(event, ctx)
+  const { user, key } = await validate(event, ctx)
   const form = await event.request.formData()
 
   const meta = /** @type {string} */ (form.get('meta'))
@@ -61,7 +61,7 @@ export async function nftStoreV1(event, ctx) {
     local: car.size > constants.cluster.localAddThreshold,
   })
 
-  await db.createUpload({
+  await ctx.db.createUpload({
     type: 'Nft',
     content_cid: cid,
     source_cid: cid,

--- a/packages/api/src/routes-v1/nfts-upload.js
+++ b/packages/api/src/routes-v1/nfts-upload.js
@@ -15,11 +15,11 @@ const LOCAL_ADD_THRESHOLD = 1024 * 1024 * 2.5
  * @typedef {import('@nftstorage/ipfs-cluster').API.StatusResponse} StatusResponse
  */
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function uploadV1(event, ctx) {
   const { headers } = event.request
   const contentType = headers.get('content-type') || ''
-  const { user, key, db } = await validate(event, ctx)
+  const { user, key } = await validate(event, ctx)
 
   /** @type {import('../utils/db-client-types').UploadOutput} */
   let upload
@@ -40,7 +40,7 @@ export async function uploadV1(event, ctx) {
 
     sourceCid = cid
 
-    upload = await db.createUpload({
+    upload = await ctx.db.createUpload({
       user_id: user.id,
       content_cid: cid,
       source_cid: cid,
@@ -80,7 +80,7 @@ export async function uploadV1(event, ctx) {
       ;({ contentCid } = parseCid(cid))
     }
 
-    upload = await db.createUpload({
+    upload = await ctx.db.createUpload({
       mime_type: blob.type,
       type: isCar ? 'Car' : 'Blob',
       content_cid: contentCid,

--- a/packages/api/src/routes-v1/pins-add.js
+++ b/packages/api/src/routes-v1/pins-add.js
@@ -4,9 +4,9 @@ import { validate } from '../utils/auth-v1.js'
 import { parseCidPinning } from '../utils/utils.js'
 import { toPinsResponse } from '../utils/db-transforms.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function pinsAddV1(event, ctx) {
-  const { db, user, key } = await validate(event, ctx)
+  const { user, key } = await validate(event, ctx)
 
   /** @type {import('../bindings').PinsAddInput} */
   const pinData = await event.request.json()
@@ -53,7 +53,7 @@ export async function pinsAddV1(event, ctx) {
     metadata: pinData.meta,
   })
 
-  const upload = await db.createUpload({
+  const upload = await ctx.db.createUpload({
     type: 'Remote',
     content_cid: cid.contentCid,
     source_cid: cid.sourceCid,

--- a/packages/api/src/routes-v1/pins-delete.js
+++ b/packages/api/src/routes-v1/pins-delete.js
@@ -2,10 +2,10 @@ import { JSONResponse } from '../utils/json-response.js'
 import { validate } from '../utils/auth-v1.js'
 import { parseCidPinning } from '../utils/utils.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function pinsDeleteV1(event, ctx) {
   const { params } = ctx
-  const { user, db } = await validate(event, ctx)
+  const { user } = await validate(event, ctx)
 
   const cid = parseCidPinning(params.requestid)
   if (!cid) {
@@ -20,7 +20,7 @@ export async function pinsDeleteV1(event, ctx) {
     )
   }
 
-  const data = await db.deleteUpload(cid.sourceCid, user.id)
+  const data = await ctx.db.deleteUpload(cid.sourceCid, user.id)
   if (data) {
     return new JSONResponse(undefined, { status: 202 })
   } else {

--- a/packages/api/src/routes-v1/pins-get.js
+++ b/packages/api/src/routes-v1/pins-get.js
@@ -3,10 +3,10 @@ import { toPinsResponse } from '../utils/db-transforms.js'
 import { JSONResponse } from '../utils/json-response.js'
 import { parseCidPinning } from '../utils/utils.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function pinsGetV1(event, ctx) {
   const { params } = ctx
-  const { user, db } = await validate(event, ctx)
+  const { user } = await validate(event, ctx)
 
   const cid = parseCidPinning(params.requestid)
   if (!cid) {
@@ -21,7 +21,7 @@ export async function pinsGetV1(event, ctx) {
     )
   }
 
-  const upload = await db.getUpload(cid.sourceCid, user.id)
+  const upload = await ctx.db.getUpload(cid.sourceCid, user.id)
 
   if (!upload) {
     return new JSONResponse(

--- a/packages/api/src/routes-v1/pins-list.js
+++ b/packages/api/src/routes-v1/pins-list.js
@@ -11,9 +11,9 @@ const MAX_LIMIT = 1000
  * @typedef {import('../utils/db-client-types').ListUploadsOptions} ListUploadsOptions
  */
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function pinsListV1(event, ctx) {
-  const { user, db } = await validate(event, ctx)
+  const { user } = await validate(event, ctx)
   const { searchParams } = new URL(event.request.url)
   const result = parseSearchParams(searchParams)
 
@@ -23,7 +23,7 @@ export async function pinsListV1(event, ctx) {
     const params = result.data
 
     // Query database
-    const data = await db.listUploads(user.id, params)
+    const data = await ctx.db.listUploads(user.id, params)
 
     // Not found
     if (!data || data.length === 0) {

--- a/packages/api/src/routes-v1/pins-replace.js
+++ b/packages/api/src/routes-v1/pins-replace.js
@@ -4,12 +4,12 @@ import { validate } from '../utils/auth-v1.js'
 import { parseCidPinning } from '../utils/utils.js'
 import { toPinsResponse } from '../utils/db-transforms.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function pinsReplace(event, ctx) {
-  const { db, user, key } = await validate(event, ctx)
+  const { user, key } = await validate(event, ctx)
 
   const existingCid = ctx.params.requestid
-  const existingUpload = await db.getUpload(existingCid, user.id)
+  const existingUpload = await ctx.db.getUpload(existingCid, user.id)
 
   if (!existingUpload) {
     return new JSONResponse(
@@ -75,7 +75,7 @@ export async function pinsReplace(event, ctx) {
     metadata: pinData.meta,
   })
 
-  const upload = await db.createUpload({
+  const upload = await ctx.db.createUpload({
     type: 'Remote',
     content_cid: cid.contentCid,
     source_cid: cid.sourceCid,
@@ -86,7 +86,7 @@ export async function pinsReplace(event, ctx) {
     name: pinData.name,
   })
 
-  await db.deleteUpload(existingCid, user.id)
+  await ctx.db.deleteUpload(existingCid, user.id)
 
   return new JSONResponse(toPinsResponse(upload))
 }

--- a/packages/api/src/routes-v1/tokens-create.js
+++ b/packages/api/src/routes-v1/tokens-create.js
@@ -3,9 +3,9 @@ import { JSONResponse } from '../utils/json-response.js'
 import { signJWT } from '../utils/jwt.js'
 import { secrets } from '../constants.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export const tokensCreateV1 = async (event, ctx) => {
-  const { db, user } = await validate(event, ctx)
+  const { user } = await validate(event, ctx)
   const body = await event.request.json()
 
   if (body.name) {
@@ -20,7 +20,7 @@ export const tokensCreateV1 = async (event, ctx) => {
       secrets.salt
     )
 
-    const key = await db.createKey({
+    const key = await ctx.db.createKey({
       name: body.name,
       secret: token,
       userId: user.id,

--- a/packages/api/src/routes-v1/tokens-delete.js
+++ b/packages/api/src/routes-v1/tokens-delete.js
@@ -1,13 +1,13 @@
 import { validate } from '../utils/auth-v1.js'
 import { JSONResponse } from '../utils/json-response.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export const tokensDeleteV1 = async (event, ctx) => {
-  const { user, db } = await validate(event, ctx)
+  const { user } = await validate(event, ctx)
   const body = await event.request.json()
 
   if (body.id) {
-    await db.deleteKey(user.id, body.id)
+    await ctx.db.deleteKey(user.id, body.id)
   } else {
     throw new Error('Token id is required.')
   }

--- a/packages/api/src/routes-v1/tokens-list.js
+++ b/packages/api/src/routes-v1/tokens-list.js
@@ -1,11 +1,11 @@
 import { validate } from '../utils/auth-v1.js'
 import { JSONResponse } from '../utils/json-response.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export const tokensListV1 = async (event, ctx) => {
-  const { user, db } = await validate(event, ctx)
+  const { user } = await validate(event, ctx)
 
-  const keys = await db.listKeys(user.id)
+  const keys = await ctx.db.listKeys(user.id)
 
   return new JSONResponse({
     ok: true,

--- a/packages/api/src/routes/get-nft.js
+++ b/packages/api/src/routes/get-nft.js
@@ -6,7 +6,7 @@ import { CID } from 'multiformats'
  * Special route to get nfts for the migration
  */
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function getNFT(event, ctx) {
   const { searchParams } = new URL(event.request.url)
   const key = searchParams.get('key') || ''

--- a/packages/api/src/routes/login.js
+++ b/packages/api/src/routes/login.js
@@ -1,7 +1,7 @@
 import { JSONResponse } from '../utils/json-response.js'
 import { loginOrRegister } from '../utils/auth.js'
 
-/** @type {import('../utils/router').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function login(event) {
   const data = await event.request.json()
   const auth = await loginOrRegister(event, data)

--- a/packages/api/src/routes/nfts-check.js
+++ b/packages/api/src/routes/nfts-check.js
@@ -3,7 +3,7 @@ import { get as getDeals } from '../models/deals.js'
 import * as pins from '../models/pins.js'
 import { HTTPError } from '../errors.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export const check = async (event, { params }) => {
   const { cid } = params
   const [pin, deals] = await Promise.all([pins.get(cid), getDeals(cid)])

--- a/packages/api/src/routes/nfts-delete.js
+++ b/packages/api/src/routes/nfts-delete.js
@@ -2,7 +2,7 @@ import * as nfts from '../models/nfts.js'
 import { validate } from '../utils/auth.js'
 import { JSONResponse } from '../utils/json-response.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export const remove = async (event, ctx) => {
   const { user } = await validate(event, ctx)
   const { params } = ctx

--- a/packages/api/src/routes/nfts-get.js
+++ b/packages/api/src/routes/nfts-get.js
@@ -9,7 +9,7 @@ import { validate } from '../utils/auth.js'
  * @typedef {import('../bindings').Deal} Deal
  */
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export const status = async (event, ctx) => {
   const { params } = ctx
   const { user } = await validate(event, ctx)

--- a/packages/api/src/routes/nfts-list.js
+++ b/packages/api/src/routes/nfts-list.js
@@ -2,7 +2,7 @@ import { JSONResponse } from '../utils/json-response.js'
 import * as nfts from '../models/nfts.js'
 import { validate } from '../utils/auth.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function list(event, ctx) {
   const auth = await validate(event, ctx)
   const options = {}

--- a/packages/api/src/routes/nfts-store.js
+++ b/packages/api/src/routes/nfts-store.js
@@ -19,7 +19,7 @@ const log = debug('nft-store')
  * @typedef {import('../bindings').NFT} NFT
  */
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function store(event, ctx) {
   const { user, tokenName } = await validate(event, ctx)
   const form = await event.request.formData()

--- a/packages/api/src/routes/nfts-upload.js
+++ b/packages/api/src/routes/nfts-upload.js
@@ -15,7 +15,7 @@ const LOCAL_ADD_THRESHOLD = constants.cluster.localAddThreshold
  * @typedef {import('../bindings').NFT} NFT
  */
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function upload(event, ctx) {
   const { headers } = event.request
   const contentType = headers.get('content-type') || ''

--- a/packages/api/src/routes/pins-add.js
+++ b/packages/api/src/routes/pins-add.js
@@ -11,7 +11,7 @@ import { debug } from '../utils/debug.js'
 const merge = mergeOptions.bind({ ignoreUndefined: true })
 const log = debug('pins-add')
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function pinsAdd(event, ctx) {
   const { user, tokenName } = await validate(event, ctx)
   const pinData = await event.request.json()

--- a/packages/api/src/routes/pins-delete.js
+++ b/packages/api/src/routes/pins-delete.js
@@ -3,7 +3,7 @@ import { JSONResponse } from '../utils/json-response.js'
 import * as nfts from '../models/nfts.js'
 import { validate } from '../utils/auth.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function pinsDelete(event, ctx) {
   const { params } = ctx
   const { user } = await validate(event, ctx)

--- a/packages/api/src/routes/pins-get.js
+++ b/packages/api/src/routes/pins-get.js
@@ -5,7 +5,7 @@ import * as nfts from '../models/nfts.js'
 import * as pins from '../models/pins.js'
 import * as cluster from '../cluster.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function pinsGet(event, ctx) {
   const { params } = ctx
   const { user } = await validate(event, ctx)

--- a/packages/api/src/routes/pins-list.js
+++ b/packages/api/src/routes/pins-list.js
@@ -3,7 +3,7 @@ import { validate } from '../utils/auth.js'
 import { JSONResponse } from '../utils/json-response.js'
 import * as nftsIndex from '../models/nfts-index.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function pinsList(event, ctx) {
   const { user } = await validate(event, ctx)
   const { searchParams } = new URL(event.request.url)

--- a/packages/api/src/routes/pins-replace.js
+++ b/packages/api/src/routes/pins-replace.js
@@ -12,7 +12,7 @@ import { debug } from '../utils/debug.js'
 const merge = mergeOptions.bind({ ignoreUndefined: true })
 const log = debug('pin-replace')
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export async function pinsReplace(event, ctx) {
   const { params } = ctx
   const { user, tokenName } = await validate(event, ctx)

--- a/packages/api/src/routes/tokens-create.js
+++ b/packages/api/src/routes/tokens-create.js
@@ -2,7 +2,7 @@ import { validate } from '../utils/auth.js'
 import { JSONResponse } from '../utils/json-response.js'
 import { createToken } from '../models/users.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export const tokensCreate = async (event, ctx) => {
   const { user } = await validate(event, ctx)
   const body = await event.request.json()

--- a/packages/api/src/routes/tokens-delete.js
+++ b/packages/api/src/routes/tokens-delete.js
@@ -2,7 +2,7 @@ import { validate } from '../utils/auth.js'
 import { JSONResponse } from '../utils/json-response.js'
 import { deleteToken } from '../models/users.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export const tokensDelete = async (event, ctx) => {
   const { user } = await validate(event, ctx)
   const body = await event.request.json()

--- a/packages/api/src/routes/tokens-list.js
+++ b/packages/api/src/routes/tokens-list.js
@@ -2,7 +2,7 @@ import { validate } from '../utils/auth.js'
 import { JSONResponse } from '../utils/json-response.js'
 import { tokens } from '../models/users.js'
 
-/** @type {import('../utils/router.js').Handler} */
+/** @type {import('../bindings').Handler} */
 export const tokensList = async (event, ctx) => {
   const { user } = await validate(event, ctx)
 

--- a/packages/api/src/utils/auth.js
+++ b/packages/api/src/utils/auth.js
@@ -18,7 +18,7 @@ export const magic = new Magic(secrets.magic)
  * Validate auth
  *
  * @param {FetchEvent} event
- * @param {import('./router.js').RouteContext} ctx
+ * @param {import('../bindings').RouteContext} ctx
  */
 export async function validate(event, { sentry }) {
   const auth = event.request.headers.get('Authorization') || ''

--- a/packages/api/src/utils/context.js
+++ b/packages/api/src/utils/context.js
@@ -1,0 +1,17 @@
+import { DBClient } from './db-client.js'
+import { getSentry } from './debug.js'
+import { secrets, database } from '../constants.js'
+
+const db = new DBClient(database.url, secrets.database)
+
+/**
+ * Obtains a route context object.
+ *
+ * @param {FetchEvent} event
+ * @param {Record<string, string>} params Parameters from the URL
+ * @returns {import('../bindings').RouteContext}
+ */
+export function getContext (event, params) {
+  const sentry = getSentry(event)
+  return { params, sentry, db }
+}

--- a/packages/api/test/maintenance.spec.js
+++ b/packages/api/test/maintenance.spec.js
@@ -10,7 +10,7 @@ import {
 
 describe('maintenance middleware', () => {
   it('should throw error when in maintenance', () => {
-    /** @type {import('../src/utils/router.js').Handler} */
+    /** @type {import('../src/bindings').Handler} */
     let handler
     const block = () => {
       // @ts-expect-error not passing params to our test handler
@@ -35,7 +35,7 @@ describe('maintenance middleware', () => {
   })
 
   it('should throw for invalid maintenance mode', () => {
-    /** @type {import('../src/utils/router.js').Handler} */
+    /** @type {import('../src/bindings').Handler} */
     const handler = withMode(() => new Response(), READ_WRITE)
     const block = () => {
       // @ts-expect-error not passing params to our test handler

--- a/packages/api/test/scripts/fixtures.js
+++ b/packages/api/test/scripts/fixtures.js
@@ -193,5 +193,170 @@ export const fixtures = {
       batchRootCid:
         'bafybeifaow2p3qrzndvr4dzvms7fun3e3bijuwkwrmzou4zupatyennufy',
     },
+    {
+      status: 'active',
+      lastChanged: '2021-10-22T01:41:51.308485+00:00',
+      chainDealID: 2639405,
+      datamodelSelector: 'Links/19/Hash/Links/824/Hash/Links/13/Hash',
+      statusText:
+        'containing sector active as of 2021-10-22 01:30:00 at epoch 1218660',
+      dealActivation: '2021-10-22T19:16:30+00:00',
+      dealExpiration: '2023-03-16T19:16:30+00:00',
+      miner: 'f020378',
+      pieceCid:
+        'baga6ea4seaqi3u2amdhq6dba6kdaccbevfcbqskvqkutdfphfjsa7ntitll7ajy',
+      batchRootCid:
+        'bafybeifaow2p3qrzndvr4dzvms7fun3e3bijuwkwrmzou4zupatyennufy',
+    },
+    {
+      status: 'active',
+      lastChanged: '2021-10-22T01:51:01.511898+00:00',
+      chainDealID: 2639406,
+      datamodelSelector: 'Links/19/Hash/Links/824/Hash/Links/13/Hash',
+      statusText:
+        'containing sector active as of 2021-10-22 01:41:30 at epoch 1218683',
+      dealActivation: '2021-10-22T19:17:30+00:00',
+      dealExpiration: '2023-03-16T19:17:30+00:00',
+      miner: 'f020378',
+      pieceCid:
+        'baga6ea4seaqi3u2amdhq6dba6kdaccbevfcbqskvqkutdfphfjsa7ntitll7ajy',
+      batchRootCid:
+        'bafybeifaow2p3qrzndvr4dzvms7fun3e3bijuwkwrmzou4zupatyennufy',
+    },
+    {
+      status: 'active',
+      lastChanged: '2021-10-22T02:36:13.915767+00:00',
+      chainDealID: 2639407,
+      datamodelSelector: 'Links/19/Hash/Links/824/Hash/Links/13/Hash',
+      statusText:
+        'containing sector active as of 2021-10-22 02:27:30 at epoch 1218775',
+      dealActivation: '2021-10-22T20:15:30+00:00',
+      dealExpiration: '2023-03-16T20:15:30+00:00',
+      miner: 'f032824',
+      pieceCid:
+        'baga6ea4seaqi3u2amdhq6dba6kdaccbevfcbqskvqkutdfphfjsa7ntitll7ajy',
+      batchRootCid:
+        'bafybeifaow2p3qrzndvr4dzvms7fun3e3bijuwkwrmzou4zupatyennufy',
+    },
+    {
+      status: 'active',
+      lastChanged: '2021-10-22T03:11:28.963024+00:00',
+      chainDealID: 2639631,
+      datamodelSelector: 'Links/19/Hash/Links/824/Hash/Links/13/Hash',
+      statusText:
+        'containing sector active as of 2021-10-22 03:01:30 at epoch 1218843',
+      dealActivation: '2021-10-23T07:18:00+00:00',
+      dealExpiration: '2023-03-17T07:18:00+00:00',
+      miner: 'f010088',
+      pieceCid:
+        'baga6ea4seaqi3u2amdhq6dba6kdaccbevfcbqskvqkutdfphfjsa7ntitll7ajy',
+      batchRootCid:
+        'bafybeifaow2p3qrzndvr4dzvms7fun3e3bijuwkwrmzou4zupatyennufy',
+    },
+    {
+      status: 'active',
+      lastChanged: '2021-10-22T05:01:26.371444+00:00',
+      chainDealID: 2639597,
+      datamodelSelector: 'Links/19/Hash/Links/824/Hash/Links/13/Hash',
+      statusText:
+        'containing sector active as of 2021-10-22 04:53:30 at epoch 1219067',
+      dealActivation: '2021-10-22T19:17:00+00:00',
+      dealExpiration: '2023-03-16T19:17:00+00:00',
+      miner: 'f010479',
+      pieceCid:
+        'baga6ea4seaqi3u2amdhq6dba6kdaccbevfcbqskvqkutdfphfjsa7ntitll7ajy',
+      batchRootCid:
+        'bafybeifaow2p3qrzndvr4dzvms7fun3e3bijuwkwrmzou4zupatyennufy',
+    },
+    {
+      status: 'active',
+      lastChanged: '2021-10-22T05:26:24.346663+00:00',
+      chainDealID: 2639408,
+      datamodelSelector: 'Links/19/Hash/Links/824/Hash/Links/13/Hash',
+      statusText:
+        'containing sector active as of 2021-10-22 05:15:30 at epoch 1219111',
+      dealActivation: '2021-10-23T18:45:30+00:00',
+      dealExpiration: '2023-03-17T18:45:30+00:00',
+      miner: 'f0678914',
+      pieceCid:
+        'baga6ea4seaqi3u2amdhq6dba6kdaccbevfcbqskvqkutdfphfjsa7ntitll7ajy',
+      batchRootCid:
+        'bafybeifaow2p3qrzndvr4dzvms7fun3e3bijuwkwrmzou4zupatyennufy',
+    },
+    {
+      status: 'active',
+      lastChanged: '2021-10-23T02:21:08.965312+00:00',
+      chainDealID: 2639350,
+      datamodelSelector: 'Links/19/Hash/Links/824/Hash/Links/13/Hash',
+      statusText:
+        'containing sector active as of 2021-10-23 02:12:00 at epoch 1221624',
+      dealActivation: '2021-10-23T18:45:30+00:00',
+      dealExpiration: '2023-03-17T18:45:30+00:00',
+      miner: 'f066596',
+      pieceCid:
+        'baga6ea4seaqi3u2amdhq6dba6kdaccbevfcbqskvqkutdfphfjsa7ntitll7ajy',
+      batchRootCid:
+        'bafybeifaow2p3qrzndvr4dzvms7fun3e3bijuwkwrmzou4zupatyennufy',
+    },
+    {
+      status: 'active',
+      lastChanged: '2021-10-27T05:36:01.21035+00:00',
+      chainDealID: 2671325,
+      datamodelSelector: 'Links/19/Hash/Links/77/Hash/Links/0/Hash',
+      statusText:
+        'containing sector active as of 2021-10-27 05:26:00 at epoch 1233532',
+      dealActivation: '2021-10-27T23:01:00+00:00',
+      dealExpiration: '2023-03-21T23:01:00+00:00',
+      miner: 'f020378',
+      pieceCid:
+        'baga6ea4seaqp3tnaexmbx7nj25ojsicpuob3ayvxqbz4ebzmbjhcepla42xx6py',
+      batchRootCid:
+        'bafybeib7kskjnu2nxmdhfmffb26y6jqufcvjtevxpkje2v67qchlfgop4q',
+    },
+    {
+      status: 'active',
+      lastChanged: '2021-11-07T10:21:22.260623+00:00',
+      chainDealID: 2721761,
+      datamodelSelector: 'Links/19/Hash/Links/77/Hash/Links/0/Hash',
+      statusText:
+        'containing sector active as of 2021-11-07 10:10:30 at epoch 1265781',
+      dealActivation: '2021-11-07T16:28:00+00:00',
+      dealExpiration: '2023-04-01T16:28:00+00:00',
+      miner: 'f01392893',
+      pieceCid:
+        'baga6ea4seaqp3tnaexmbx7nj25ojsicpuob3ayvxqbz4ebzmbjhcepla42xx6py',
+      batchRootCid:
+        'bafybeib7kskjnu2nxmdhfmffb26y6jqufcvjtevxpkje2v67qchlfgop4q',
+    },
+    {
+      status: 'active',
+      lastChanged: '2021-11-07T11:15:57.579222+00:00',
+      chainDealID: 2722096,
+      datamodelSelector: 'Links/19/Hash/Links/77/Hash/Links/0/Hash',
+      statusText:
+        'containing sector active as of 2021-11-07 11:09:30 at epoch 1265899',
+      dealActivation: '2021-11-08T12:58:00+00:00',
+      dealExpiration: '2023-04-02T12:58:00+00:00',
+      miner: 'f0840770',
+      pieceCid:
+        'baga6ea4seaqp3tnaexmbx7nj25ojsicpuob3ayvxqbz4ebzmbjhcepla42xx6py',
+      batchRootCid:
+        'bafybeib7kskjnu2nxmdhfmffb26y6jqufcvjtevxpkje2v67qchlfgop4q',
+    },
+    {
+      status: 'active',
+      lastChanged: '2021-11-07T14:46:10.945128+00:00',
+      chainDealID: 2721970,
+      datamodelSelector: 'Links/19/Hash/Links/77/Hash/Links/0/Hash',
+      statusText:
+        'containing sector active as of 2021-11-07 14:37:00 at epoch 1266314',
+      dealActivation: '2021-11-08T03:08:00+00:00',
+      dealExpiration: '2023-04-02T03:08:00+00:00',
+      miner: 'f010479',
+      pieceCid:
+        'baga6ea4seaqp3tnaexmbx7nj25ojsicpuob3ayvxqbz4ebzmbjhcepla42xx6py',
+      batchRootCid:
+        'bafybeib7kskjnu2nxmdhfmffb26y6jqufcvjtevxpkje2v67qchlfgop4q',
+    },
   ],
 }


### PR DESCRIPTION
This PR is a refactor that changes the way routes obtain the DB client. Instead of it being returned from the `validate` function in `auth-v1.js` it is attached to the `RouteContext` so every route has access to it so they don't need to instantiate their own if they don't use `validate`.

The `Router` is now agnostic to the route context type, mandating only that it extends a `BasicRouteContext` which contains the URL parameters. It's constructor now takes a function that creates the context object as a parameter.

There is concrete `RouteContext` and `Handler<RouteContext>` types in `bindings.d.ts` which are used by our routes. The handler conforms to the `Handler<T extends BasicRouteContext>` type required by the router.

I've done this for consistency - I will add an s3 client to the `RouteContext` next.