### PR TITLE
feat: indexes for slow queries

### DIFF
--- a/packages/api/db/tables.sql
+++ b/packages/api/db/tables.sql
@@ -80,6 +80,7 @@ CREATE TABLE IF NOT EXISTS content
 );
 
 CREATE INDEX IF NOT EXISTS content_updated_at_idx ON content (updated_at);
+CREATE INDEX IF NOT EXISTS content_inserted_at_idx ON content (inserted_at);
 
 -- Information for piece of content pinned in IPFS.
 CREATE TABLE IF NOT EXISTS pin
@@ -129,6 +130,7 @@ CREATE TABLE IF NOT EXISTS upload
     UNIQUE (user_id, source_cid)
 );
 
+CREATE INDEX IF NOT EXISTS upload_source_cid_idx ON upload (source_cid);
 CREATE INDEX IF NOT EXISTS upload_updated_at_idx ON upload (updated_at);
 
 -- Temporary table to record events from the live site between KV sync start


### PR DESCRIPTION
Indexes for the following slow queries:

```sql
SELECT cid
FROM public.content
WHERE (dag_size IS NULL
        OR dag_size = $4)
        AND inserted_at > $1 OFFSET $2 LIMIT $3
```

```sql
SELECT source_cid
FROM upload
WHERE user_id = $2
        AND source_cid = ANY($1)
```