### PR TITLE
fix: update links to moved repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Free decentralized storage and bandwidth for NFTs on IPFS and Filecoin.
 
-<a href="https://nft.storage"><img src="https://raw.githubusercontent.com/ipfs-shipyard/nft.storage/main/screenshot.png" alt="nft.storage screenshot" /></a>
+<a href="https://nft.storage"><img src="https://raw.githubusercontent.com/nftstorage/nft.storage/main/screenshot.png" alt="nft.storage screenshot" /></a>
 
 # Table of Contents <!-- omit in toc -->
 
@@ -22,7 +22,7 @@ Free decentralized storage and bandwidth for NFTs on IPFS and Filecoin.
 
 The JS client library is the official and supported client to nft.storage. Other libraries listed have been generated from the [OpenAPI schema](https://nft.storage/schema.yml) and are experimental, unsupported and may not work at all!
 
-- [JavaScript](https://github.com/ipfs-shipyard/nft.storage/tree/main/packages/client)
+- [JavaScript](https://github.com/nftstorage/nft.storage/tree/main/packages/client)
 - [Go](https://github.com/nftstorage/go-client) (Generated from OpenAPI schema)
 - [Java](https://github.com/nftstorage/java-client) (Generated from OpenAPI schema)
 - [PHP](https://github.com/nftstorage/php-client) (Generated from OpenAPI schema)
@@ -101,8 +101,8 @@ The most important prefixes you should have in mind are:
 
 # Contributing
 
-Feel free to join in. All welcome. [Open an issue](https://github.com/ipfs-shipyard/nft.storage/issues)!
+Feel free to join in. All welcome. [Open an issue](https://github.com/nftstorage/nft.storage/issues)!
 
 # License
 
-Dual-licensed under [MIT](https://github.com/ipfs-shipyard/nft.storage/blob/main/LICENSE-MIT) + [Apache 2.0](https://github.com/ipfs-shipyard/nft.storage/blob/main/LICENSE-APACHE)
+Dual-licensed under [MIT](https://github.com/nftstorage/nft.storage/blob/main/LICENSE-MIT) + [Apache 2.0](https://github.com/nftstorage/nft.storage/blob/main/LICENSE-APACHE)

--- a/docs/client/classes/NFTStorage.html
+++ b/docs/client/classes/NFTStorage.html
@@ -133,7 +133,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L56">packages/client/src/lib.js:56</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L56">packages/client/src/lib.js:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">endpoint<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">URL</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L67">packages/client/src/lib.js:67</a></li>
+							<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L67">packages/client/src/lib.js:67</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L62">packages/client/src/lib.js:62</a></li>
+							<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L62">packages/client/src/lib.js:62</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -232,7 +232,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L390">packages/client/src/lib.js:390</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L390">packages/client/src/lib.js:390</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -269,7 +269,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L376">packages/client/src/lib.js:376</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L376">packages/client/src/lib.js:376</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -309,7 +309,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L360">packages/client/src/lib.js:360</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L360">packages/client/src/lib.js:360</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -346,7 +346,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L433">packages/client/src/lib.js:433</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L433">packages/client/src/lib.js:433</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -412,7 +412,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L286">packages/client/src/lib.js:286</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L286">packages/client/src/lib.js:286</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -453,7 +453,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L326">packages/client/src/lib.js:326</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L326">packages/client/src/lib.js:326</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -513,7 +513,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L346">packages/client/src/lib.js:346</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L346">packages/client/src/lib.js:346</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -555,7 +555,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L236">packages/client/src/lib.js:236</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L236">packages/client/src/lib.js:236</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -581,7 +581,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L257">packages/client/src/lib.js:257</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L257">packages/client/src/lib.js:257</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -607,7 +607,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L210">packages/client/src/lib.js:210</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L210">packages/client/src/lib.js:210</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -633,7 +633,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L182">packages/client/src/lib.js:182</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L182">packages/client/src/lib.js:182</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -665,7 +665,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L83">packages/client/src/lib.js:83</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L83">packages/client/src/lib.js:83</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -691,7 +691,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L109">packages/client/src/lib.js:109</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L109">packages/client/src/lib.js:109</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -720,7 +720,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L147">packages/client/src/lib.js:147</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L147">packages/client/src/lib.js:147</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/client/index.html
+++ b/docs/client/index.html
@@ -61,12 +61,12 @@
 				<a href="#nftstorage" id="nftstorage" style="color: inherit; text-decoration: none;">
 					<h1>nft.storage</h1>
 				</a>
-				<p><img src="https://github.com/ipfs-shipyard/nft.storage/actions/workflows/client.yml/badge.svg" alt="ci">
+				<p><img src="https://github.com/nftstorage/nft.storage/actions/workflows/client.yml/badge.svg" alt="ci">
 					<a href="https://npmjs.org/package/nft.storage"><img src="https://img.shields.io/npm/v/nft.storage.svg" alt="package"></a>
 					<a href="https://github.com/prettier/prettier"><img src="https://img.shields.io/badge/styled_with-prettier-ff69b4.svg" alt="styled with prettier"></a>
 					<a href="https://bundlephobia.com/result?p=nft.storage"><img src="https://badgen.net/bundlephobia/minzip/nft.storage" alt="size"></a>
-					<a href="https://david-dm.org/ipfs-shipyard/nft.storage?path=packages/client"><img src="https://status.david-dm.org/gh/ipfs-shipyard/nft.storage.svg?path=packages/client" alt="deps"></a>
-				<a href="https://codecov.io/gh/ipfs-shipyard/nft.storage"><img src="https://codecov.io/gh/ipfs-shipyard/nft.storage/branch/main/graph/badge.svg?token=dU5oWrlqHF" alt="codecov"></a></p>
+					<a href="https://david-dm.org/nftstorage/nft.storage?path=packages/client"><img src="https://status.david-dm.org/gh/nftstorage/nft.storage.svg?path=packages/client" alt="deps"></a>
+				<a href="https://codecov.io/gh/nftstorage/nft.storage"><img src="https://codecov.io/gh/nftstorage/nft.storage/branch/main/graph/badge.svg?token=dU5oWrlqHF" alt="codecov"></a></p>
 				<p>A client library for the <a href="https://nft.storage/">https://nft.storage/</a> service. It provides a convenient interface for working with the <a href="https://nft.storage/#api-docs">Raw HTTP API</a> from a web browser or <a href="https://nodejs.org/">Node.js</a> and comes bundled with TS for out-of-the box type inference and better IntelliSense.</p>
 				<a href="#install" id="install" style="color: inherit; text-decoration: none;">
 					<h2>Install</h2>
@@ -98,7 +98,7 @@
 <span style="color: #001080">console</span><span style="color: #000000">.</span><span style="color: #795E26">log</span><span style="color: #000000">(</span><span style="color: #001080">metadata</span><span style="color: #000000">.</span><span style="color: #001080">url</span><span style="color: #000000">)</span>
 <span style="color: #008000">// ipfs://bafyreib4pff766vhpbxbhjbqqnsh5emeznvujayjj4z2iu533cprgbz23m/metadata.json</span>
 </code></pre>
-				<p>For more examples please see the <a href="https://ipfs-shipyard.github.io/nft.storage/client/">API documentation</a> or the <a href="https://github.com/ipfs-shipyard/nft.storage/tree/main/packages/client/examples">examples directory in the project repository</a>, which contains sample projects for both <a href="https://github.com/ipfs-shipyard/nft.storage/tree/main/packages/client/examples/browser">browsers</a> and <a href="https://github.com/ipfs-shipyard/nft.storage/tree/main/packages/client/examples/node.js">Node.js</a>.</p>
+				<p>For more examples please see the <a href="https://nftstorage.github.io/nft.storage/client/">API documentation</a> or the <a href="https://github.com/nftstorage/nft.storage/tree/main/packages/client/examples">examples directory in the project repository</a>, which contains sample projects for both <a href="https://github.com/nftstorage/nft.storage/tree/main/packages/client/examples/browser">browsers</a> and <a href="https://github.com/nftstorage/nft.storage/tree/main/packages/client/examples/node.js">Node.js</a>.</p>
 			</div>
 		</div>
 		<div class="col-4 col-menu menu-sticky-wrap menu-highlight">

--- a/docs/client/modules.html
+++ b/docs/client/modules.html
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">Blob<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>prototype<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Blob</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/platform.ts#L6">packages/client/src/platform.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/platform.ts#L6">packages/client/src/platform.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">File<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>prototype<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">File</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/platform.ts#L7">packages/client/src/platform.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/platform.ts#L7">packages/client/src/platform.ts:7</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">Form<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>prototype<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">FormData</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/platform.ts#L2">packages/client/src/platform.ts:2</a></li>
+							<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/platform.ts#L2">packages/client/src/platform.ts:2</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><span class="tsd-signature-type">Token</span><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L494">packages/client/src/lib.js:494</a></li>
+							<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/lib.js#L494">packages/client/src/lib.js:494</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ipfs-shipyard/nft.storage/blob/83ae1c8/packages/client/src/gateway.js#L17">packages/client/src/gateway.js:17</a></li>
+									<li>Defined in <a href="https://github.com/nftstorage/nft.storage/blob/83ae1c8/packages/client/src/gateway.js#L17">packages/client/src/gateway.js:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,178 +1,178 @@
 # Changelog
 
-### [2.7.3](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v2.7.2...api-v2.7.3) (2021-10-20)
+### [2.7.3](https://www.github.com/nftstorage/nft.storage/compare/api-v2.7.2...api-v2.7.3) (2021-10-20)
 
 
 ### Bug Fixes
 
-* disallow delete another users key ([#641](https://www.github.com/ipfs-shipyard/nft.storage/issues/641)) ([f53c223](https://www.github.com/ipfs-shipyard/nft.storage/commit/f53c22318fabc9447f8427eff991220c5b865107))
-* pin list filtering by status ([#640](https://www.github.com/ipfs-shipyard/nft.storage/issues/640)) ([612c824](https://www.github.com/ipfs-shipyard/nft.storage/commit/612c82440ff70ebe29ebd5deec1e4dd4a9d0009d))
+* disallow delete another users key ([#641](https://www.github.com/nftstorage/nft.storage/issues/641)) ([f53c223](https://www.github.com/nftstorage/nft.storage/commit/f53c22318fabc9447f8427eff991220c5b865107))
+* pin list filtering by status ([#640](https://www.github.com/nftstorage/nft.storage/issues/640)) ([612c824](https://www.github.com/nftstorage/nft.storage/commit/612c82440ff70ebe29ebd5deec1e4dd4a9d0009d))
 
-### [2.7.2](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v2.7.1...api-v2.7.2) (2021-10-15)
-
-
-### Bug Fixes
-
-* prometheus metrics tag syntax ([1721e1d](https://www.github.com/ipfs-shipyard/nft.storage/commit/1721e1d20943f4f4c1157cccbbad36160f19f4bf))
-* remove temporary backdoor routes ([#611](https://www.github.com/ipfs-shipyard/nft.storage/issues/611)) ([e1ea7b1](https://www.github.com/ipfs-shipyard/nft.storage/commit/e1ea7b19d9346ae08a02e987599559f5a826cdbd))
-* test fixtures ([7eda172](https://www.github.com/ipfs-shipyard/nft.storage/commit/7eda172ff25285dde234cde1b665e223ec49b6c5))
-
-### [2.7.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v2.7.0...api-v2.7.1) (2021-10-14)
+### [2.7.2](https://www.github.com/nftstorage/nft.storage/compare/api-v2.7.1...api-v2.7.2) (2021-10-15)
 
 
 ### Bug Fixes
 
-* metrics exposition format ([#614](https://www.github.com/ipfs-shipyard/nft.storage/issues/614)) ([242cd3a](https://www.github.com/ipfs-shipyard/nft.storage/commit/242cd3ab1bbf459281e9febc506fd76be612a5a8))
+* prometheus metrics tag syntax ([1721e1d](https://www.github.com/nftstorage/nft.storage/commit/1721e1d20943f4f4c1157cccbbad36160f19f4bf))
+* remove temporary backdoor routes ([#611](https://www.github.com/nftstorage/nft.storage/issues/611)) ([e1ea7b1](https://www.github.com/nftstorage/nft.storage/commit/e1ea7b19d9346ae08a02e987599559f5a826cdbd))
+* test fixtures ([7eda172](https://www.github.com/nftstorage/nft.storage/commit/7eda172ff25285dde234cde1b665e223ec49b6c5))
 
-## [2.7.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v2.6.0...api-v2.7.0) (2021-10-14)
+### [2.7.1](https://www.github.com/nftstorage/nft.storage/compare/api-v2.7.0...api-v2.7.1) (2021-10-14)
+
+
+### Bug Fixes
+
+* metrics exposition format ([#614](https://www.github.com/nftstorage/nft.storage/issues/614)) ([242cd3a](https://www.github.com/nftstorage/nft.storage/commit/242cd3ab1bbf459281e9febc506fd76be612a5a8))
+
+## [2.7.0](https://www.github.com/nftstorage/nft.storage/compare/api-v2.6.0...api-v2.7.0) (2021-10-14)
 
 
 ### Features
 
-* add indexes to updated_at fields ([#598](https://www.github.com/ipfs-shipyard/nft.storage/issues/598)) ([d4f110a](https://www.github.com/ipfs-shipyard/nft.storage/commit/d4f110a03eac53b2b9d921d60da8cd0ababb09c6))
-* temporary API backdoor endpoints ([#605](https://www.github.com/ipfs-shipyard/nft.storage/issues/605)) ([e02e371](https://www.github.com/ipfs-shipyard/nft.storage/commit/e02e371964f68d8cdf3196eca47d0d657aaec50b))
+* add indexes to updated_at fields ([#598](https://www.github.com/nftstorage/nft.storage/issues/598)) ([d4f110a](https://www.github.com/nftstorage/nft.storage/commit/d4f110a03eac53b2b9d921d60da8cd0ababb09c6))
+* temporary API backdoor endpoints ([#605](https://www.github.com/nftstorage/nft.storage/issues/605)) ([e02e371](https://www.github.com/nftstorage/nft.storage/commit/e02e371964f68d8cdf3196eca47d0d657aaec50b))
 
 
 ### Bug Fixes
 
-* db diagram link ([b234556](https://www.github.com/ipfs-shipyard/nft.storage/commit/b2345563c27cdf7052e2d62ca0865f397d96014e))
-* do not allow delete of deleted NFT ([#581](https://www.github.com/ipfs-shipyard/nft.storage/issues/581)) ([fca5bde](https://www.github.com/ipfs-shipyard/nft.storage/commit/fca5bde2f008328deffce3dd01e420e26e4a02eb))
-* dont delete uploads ([#551](https://www.github.com/ipfs-shipyard/nft.storage/issues/551)) ([b797f9c](https://www.github.com/ipfs-shipyard/nft.storage/commit/b797f9c7e9cbf770b29829959b10e0bb12ee555e))
-* tests ([d294432](https://www.github.com/ipfs-shipyard/nft.storage/commit/d294432cc44c48af78bc1c3673ac61075a18710c))
-* throw an error for missing env vars ([#576](https://www.github.com/ipfs-shipyard/nft.storage/issues/576)) ([2dddc13](https://www.github.com/ipfs-shipyard/nft.storage/commit/2dddc130270db745e1dd0115085f6ff90f9d54f1))
+* db diagram link ([b234556](https://www.github.com/nftstorage/nft.storage/commit/b2345563c27cdf7052e2d62ca0865f397d96014e))
+* do not allow delete of deleted NFT ([#581](https://www.github.com/nftstorage/nft.storage/issues/581)) ([fca5bde](https://www.github.com/nftstorage/nft.storage/commit/fca5bde2f008328deffce3dd01e420e26e4a02eb))
+* dont delete uploads ([#551](https://www.github.com/nftstorage/nft.storage/issues/551)) ([b797f9c](https://www.github.com/nftstorage/nft.storage/commit/b797f9c7e9cbf770b29829959b10e0bb12ee555e))
+* tests ([d294432](https://www.github.com/nftstorage/nft.storage/commit/d294432cc44c48af78bc1c3673ac61075a18710c))
+* throw an error for missing env vars ([#576](https://www.github.com/nftstorage/nft.storage/issues/576)) ([2dddc13](https://www.github.com/nftstorage/nft.storage/commit/2dddc130270db745e1dd0115085f6ff90f9d54f1))
 
 
 ### Changes
 
-* move v1 to root (minimal changes) ([#534](https://www.github.com/ipfs-shipyard/nft.storage/issues/534)) ([c60cf6c](https://www.github.com/ipfs-shipyard/nft.storage/commit/c60cf6c06dc5812f980152fcb9b451a84cf9aba7))
+* move v1 to root (minimal changes) ([#534](https://www.github.com/nftstorage/nft.storage/issues/534)) ([c60cf6c](https://www.github.com/nftstorage/nft.storage/commit/c60cf6c06dc5812f980152fcb9b451a84cf9aba7))
 
-## [2.6.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v2.5.0...api-v2.6.0) (2021-10-11)
-
-
-### Features
-
-* migration events in postgres ([#554](https://www.github.com/ipfs-shipyard/nft.storage/issues/554)) ([391a9e5](https://www.github.com/ipfs-shipyard/nft.storage/commit/391a9e54d7b8d523364f61d3cc6c688354b23d53))
-
-
-### Bug Fixes
-
-* set range on metrics queries ([#572](https://www.github.com/ipfs-shipyard/nft.storage/issues/572)) ([08ef4de](https://www.github.com/ipfs-shipyard/nft.storage/commit/08ef4dec7524dd5bf8cdb290c7e61e9e52ea787d))
-
-## [2.5.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v2.4.0...api-v2.5.0) (2021-10-08)
+## [2.6.0](https://www.github.com/nftstorage/nft.storage/compare/api-v2.5.0...api-v2.6.0) (2021-10-11)
 
 
 ### Features
 
-* add new cluster enum and nothing else ([#509](https://www.github.com/ipfs-shipyard/nft.storage/issues/509)) ([cc4ed28](https://www.github.com/ipfs-shipyard/nft.storage/commit/cc4ed281a848af695fdb8f729f24796f7051b8b0))
-* add prom metrics endpoint generated from postgres data ([#495](https://www.github.com/ipfs-shipyard/nft.storage/issues/495)) ([a99df3d](https://www.github.com/ipfs-shipyard/nft.storage/commit/a99df3ddc4f7f056a83758548992ed98e474b59a))
-* add PSA error handler ([#512](https://www.github.com/ipfs-shipyard/nft.storage/issues/512)) ([50daf83](https://www.github.com/ipfs-shipyard/nft.storage/commit/50daf83acea8d41ee174e28fa5827d61d3782dd4))
-* **api:** deals and pin status ([#455](https://www.github.com/ipfs-shipyard/nft.storage/issues/455)) ([692d514](https://www.github.com/ipfs-shipyard/nft.storage/commit/692d5140ad323b27d431f59a189a3a6cfc56ba6c)), closes [#459](https://www.github.com/ipfs-shipyard/nft.storage/issues/459)
-* cron v1 ([#496](https://www.github.com/ipfs-shipyard/nft.storage/issues/496)) ([fa850a5](https://www.github.com/ipfs-shipyard/nft.storage/commit/fa850a5344f23cf8f520c85e982345b59f26f6b9))
-* db error reporting ([#510](https://www.github.com/ipfs-shipyard/nft.storage/issues/510)) ([d9d8579](https://www.github.com/ipfs-shipyard/nft.storage/commit/d9d8579f0eace2ffefb0e13921f55a544f27965a))
-* db migration pipeline ([#491](https://www.github.com/ipfs-shipyard/nft.storage/issues/491)) ([56b8697](https://www.github.com/ipfs-shipyard/nft.storage/commit/56b8697c65b9f86d1bc76b4e7c3001cffd36b87e))
-* do not delete auth keys ([#539](https://www.github.com/ipfs-shipyard/nft.storage/issues/539)) ([d1b07e0](https://www.github.com/ipfs-shipyard/nft.storage/commit/d1b07e0481412759c71c91eef274b0b21aa70a64))
-* maintenance mode ([#466](https://www.github.com/ipfs-shipyard/nft.storage/issues/466)) ([1627588](https://www.github.com/ipfs-shipyard/nft.storage/commit/16275886066f3530a2d79b963df2d686a6f1b7f8))
-* migrate database to postgres  ([#263](https://www.github.com/ipfs-shipyard/nft.storage/issues/263)) ([ff0c919](https://www.github.com/ipfs-shipyard/nft.storage/commit/ff0c919ad63f8452357ff5f23b3f1ecd24880c86))
+* migration events in postgres ([#554](https://www.github.com/nftstorage/nft.storage/issues/554)) ([391a9e5](https://www.github.com/nftstorage/nft.storage/commit/391a9e54d7b8d523364f61d3cc6c688354b23d53))
 
 
 ### Bug Fixes
 
-* add CORS headers to /version endpoint ([#545](https://www.github.com/ipfs-shipyard/nft.storage/issues/545)) ([08654e9](https://www.github.com/ipfs-shipyard/nft.storage/commit/08654e9e950c4784746ab23873bfe2afe835c3fb))
-* db client usage in node.js and avoid duplicate cids ([#522](https://www.github.com/ipfs-shipyard/nft.storage/issues/522)) ([6d09ae7](https://www.github.com/ipfs-shipyard/nft.storage/commit/6d09ae73aa1c79ff1d03272a803f0cde9ad1a0de))
-* db config documentation and test fixes ([#471](https://www.github.com/ipfs-shipyard/nft.storage/issues/471)) ([a1911f3](https://www.github.com/ipfs-shipyard/nft.storage/commit/a1911f31f1079cf29f74192da4cebe576c069e77))
-* do not swallow error ([6733512](https://www.github.com/ipfs-shipyard/nft.storage/commit/673351273c99c4e8997a35573ed65ea9860ef8f7))
-* min, max and default limits for v1 list endpoints ([#493](https://www.github.com/ipfs-shipyard/nft.storage/issues/493)) ([64cd15d](https://www.github.com/ipfs-shipyard/nft.storage/commit/64cd15daa74f834338057f087a6ebbe52c85a354))
-* normalize CAR file content CID ([#549](https://www.github.com/ipfs-shipyard/nft.storage/issues/549)) ([0115443](https://www.github.com/ipfs-shipyard/nft.storage/commit/0115443fde4d44396498ffbbcda8446647498f78))
-* remove nft index cron job ([#453](https://www.github.com/ipfs-shipyard/nft.storage/issues/453)) ([a93433c](https://www.github.com/ipfs-shipyard/nft.storage/commit/a93433c56ba303e10b7c594d83b02c7c6af1a1ec))
-* remove usage_model from top level ([#463](https://www.github.com/ipfs-shipyard/nft.storage/issues/463)) ([9d9391d](https://www.github.com/ipfs-shipyard/nft.storage/commit/9d9391d1a9d9eded82bdd834e70bcfcce0024770))
-* retain correct value for NFT type ([#548](https://www.github.com/ipfs-shipyard/nft.storage/issues/548)) ([ad597d0](https://www.github.com/ipfs-shipyard/nft.storage/commit/ad597d0eae302e1ea09f97d4b563840ab82c5986))
-* retrieve upload after create ([#540](https://www.github.com/ipfs-shipyard/nft.storage/issues/540)) ([8bb9b8d](https://www.github.com/ipfs-shipyard/nft.storage/commit/8bb9b8d92360829fbaac3f0b138dd95a952b9ef2))
-* use Authorization header ([79889fb](https://www.github.com/ipfs-shipyard/nft.storage/commit/79889fb2f69065e2645db99a8cbf999edd57454d))
-* use pin creation date not upload creation date ([#547](https://www.github.com/ipfs-shipyard/nft.storage/issues/547)) ([5e51ebf](https://www.github.com/ipfs-shipyard/nft.storage/commit/5e51ebf43d8a6461b74701cf2b1e12a6cb4d20b0))
+* set range on metrics queries ([#572](https://www.github.com/nftstorage/nft.storage/issues/572)) ([08ef4de](https://www.github.com/nftstorage/nft.storage/commit/08ef4dec7524dd5bf8cdb290c7e61e9e52ea787d))
+
+## [2.5.0](https://www.github.com/nftstorage/nft.storage/compare/api-v2.4.0...api-v2.5.0) (2021-10-08)
+
+
+### Features
+
+* add new cluster enum and nothing else ([#509](https://www.github.com/nftstorage/nft.storage/issues/509)) ([cc4ed28](https://www.github.com/nftstorage/nft.storage/commit/cc4ed281a848af695fdb8f729f24796f7051b8b0))
+* add prom metrics endpoint generated from postgres data ([#495](https://www.github.com/nftstorage/nft.storage/issues/495)) ([a99df3d](https://www.github.com/nftstorage/nft.storage/commit/a99df3ddc4f7f056a83758548992ed98e474b59a))
+* add PSA error handler ([#512](https://www.github.com/nftstorage/nft.storage/issues/512)) ([50daf83](https://www.github.com/nftstorage/nft.storage/commit/50daf83acea8d41ee174e28fa5827d61d3782dd4))
+* **api:** deals and pin status ([#455](https://www.github.com/nftstorage/nft.storage/issues/455)) ([692d514](https://www.github.com/nftstorage/nft.storage/commit/692d5140ad323b27d431f59a189a3a6cfc56ba6c)), closes [#459](https://www.github.com/nftstorage/nft.storage/issues/459)
+* cron v1 ([#496](https://www.github.com/nftstorage/nft.storage/issues/496)) ([fa850a5](https://www.github.com/nftstorage/nft.storage/commit/fa850a5344f23cf8f520c85e982345b59f26f6b9))
+* db error reporting ([#510](https://www.github.com/nftstorage/nft.storage/issues/510)) ([d9d8579](https://www.github.com/nftstorage/nft.storage/commit/d9d8579f0eace2ffefb0e13921f55a544f27965a))
+* db migration pipeline ([#491](https://www.github.com/nftstorage/nft.storage/issues/491)) ([56b8697](https://www.github.com/nftstorage/nft.storage/commit/56b8697c65b9f86d1bc76b4e7c3001cffd36b87e))
+* do not delete auth keys ([#539](https://www.github.com/nftstorage/nft.storage/issues/539)) ([d1b07e0](https://www.github.com/nftstorage/nft.storage/commit/d1b07e0481412759c71c91eef274b0b21aa70a64))
+* maintenance mode ([#466](https://www.github.com/nftstorage/nft.storage/issues/466)) ([1627588](https://www.github.com/nftstorage/nft.storage/commit/16275886066f3530a2d79b963df2d686a6f1b7f8))
+* migrate database to postgres  ([#263](https://www.github.com/nftstorage/nft.storage/issues/263)) ([ff0c919](https://www.github.com/nftstorage/nft.storage/commit/ff0c919ad63f8452357ff5f23b3f1ecd24880c86))
+
+
+### Bug Fixes
+
+* add CORS headers to /version endpoint ([#545](https://www.github.com/nftstorage/nft.storage/issues/545)) ([08654e9](https://www.github.com/nftstorage/nft.storage/commit/08654e9e950c4784746ab23873bfe2afe835c3fb))
+* db client usage in node.js and avoid duplicate cids ([#522](https://www.github.com/nftstorage/nft.storage/issues/522)) ([6d09ae7](https://www.github.com/nftstorage/nft.storage/commit/6d09ae73aa1c79ff1d03272a803f0cde9ad1a0de))
+* db config documentation and test fixes ([#471](https://www.github.com/nftstorage/nft.storage/issues/471)) ([a1911f3](https://www.github.com/nftstorage/nft.storage/commit/a1911f31f1079cf29f74192da4cebe576c069e77))
+* do not swallow error ([6733512](https://www.github.com/nftstorage/nft.storage/commit/673351273c99c4e8997a35573ed65ea9860ef8f7))
+* min, max and default limits for v1 list endpoints ([#493](https://www.github.com/nftstorage/nft.storage/issues/493)) ([64cd15d](https://www.github.com/nftstorage/nft.storage/commit/64cd15daa74f834338057f087a6ebbe52c85a354))
+* normalize CAR file content CID ([#549](https://www.github.com/nftstorage/nft.storage/issues/549)) ([0115443](https://www.github.com/nftstorage/nft.storage/commit/0115443fde4d44396498ffbbcda8446647498f78))
+* remove nft index cron job ([#453](https://www.github.com/nftstorage/nft.storage/issues/453)) ([a93433c](https://www.github.com/nftstorage/nft.storage/commit/a93433c56ba303e10b7c594d83b02c7c6af1a1ec))
+* remove usage_model from top level ([#463](https://www.github.com/nftstorage/nft.storage/issues/463)) ([9d9391d](https://www.github.com/nftstorage/nft.storage/commit/9d9391d1a9d9eded82bdd834e70bcfcce0024770))
+* retain correct value for NFT type ([#548](https://www.github.com/nftstorage/nft.storage/issues/548)) ([ad597d0](https://www.github.com/nftstorage/nft.storage/commit/ad597d0eae302e1ea09f97d4b563840ab82c5986))
+* retrieve upload after create ([#540](https://www.github.com/nftstorage/nft.storage/issues/540)) ([8bb9b8d](https://www.github.com/nftstorage/nft.storage/commit/8bb9b8d92360829fbaac3f0b138dd95a952b9ef2))
+* use Authorization header ([79889fb](https://www.github.com/nftstorage/nft.storage/commit/79889fb2f69065e2645db99a8cbf999edd57454d))
+* use pin creation date not upload creation date ([#547](https://www.github.com/nftstorage/nft.storage/issues/547)) ([5e51ebf](https://www.github.com/nftstorage/nft.storage/commit/5e51ebf43d8a6461b74701cf2b1e12a6cb4d20b0))
 
 
 ### Changes
 
-* rename account table to user ([#485](https://www.github.com/ipfs-shipyard/nft.storage/issues/485)) ([a3423a1](https://www.github.com/ipfs-shipyard/nft.storage/commit/a3423a18b537d7b1accdf2ffa4d716939a7bdd2a))
-* rename stored procedures ([#486](https://www.github.com/ipfs-shipyard/nft.storage/issues/486)) ([f2218dd](https://www.github.com/ipfs-shipyard/nft.storage/commit/f2218ddecf622aa7e01b7dceeefffc0fb1365d3e))
-* setup countly analytics ([#432](https://www.github.com/ipfs-shipyard/nft.storage/issues/432)) ([8b90bfa](https://www.github.com/ipfs-shipyard/nft.storage/commit/8b90bfa4ba5b2a51c9f10b169e15fa217948faed))
+* rename account table to user ([#485](https://www.github.com/nftstorage/nft.storage/issues/485)) ([a3423a1](https://www.github.com/nftstorage/nft.storage/commit/a3423a18b537d7b1accdf2ffa4d716939a7bdd2a))
+* rename stored procedures ([#486](https://www.github.com/nftstorage/nft.storage/issues/486)) ([f2218dd](https://www.github.com/nftstorage/nft.storage/commit/f2218ddecf622aa7e01b7dceeefffc0fb1365d3e))
+* setup countly analytics ([#432](https://www.github.com/nftstorage/nft.storage/issues/432)) ([8b90bfa](https://www.github.com/nftstorage/nft.storage/commit/8b90bfa4ba5b2a51c9f10b169e15fa217948faed))
 
-## [2.4.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v2.3.1...api-v2.4.0) (2021-08-27)
-
-
-### Features
-
-* remove custom multipart parser ([#336](https://www.github.com/ipfs-shipyard/nft.storage/issues/336)) ([029e71a](https://www.github.com/ipfs-shipyard/nft.storage/commit/029e71aefc1b152a080ffb5739e4f7c2565a1e57))
-
-
-### Bug Fixes
-
-* **api:** validate CID input for pins add and replace ([#314](https://www.github.com/ipfs-shipyard/nft.storage/issues/314)) ([dd5baca](https://www.github.com/ipfs-shipyard/nft.storage/commit/dd5bacac8207c715b097e7b1bc0555742c6b8488))
-* bad dag creation by store api ([#343](https://www.github.com/ipfs-shipyard/nft.storage/issues/343)) ([307e6cd](https://www.github.com/ipfs-shipyard/nft.storage/commit/307e6cd07e4b3587a404ea8fa367721f574d4e32))
-* temporarily set local=true for all uploads ([f637c86](https://www.github.com/ipfs-shipyard/nft.storage/commit/f637c86a569d1fc81a481574550e71bc02fae9ac))
-
-### [2.3.2](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v2.3.1...api-v2.3.2) (2021-08-15)
-
-
-### Bug Fixes
-
-* temporarily set local=true for all uploads ([f637c86](https://www.github.com/ipfs-shipyard/nft.storage/commit/f637c86a569d1fc81a481574550e71bc02fae9ac))
-
-### [2.3.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v2.3.0...api-v2.3.1) (2021-08-11)
-
-
-### Bug Fixes
-
-* only local add files smaller then 2.5MiB ([#287](https://www.github.com/ipfs-shipyard/nft.storage/issues/287)) ([a225fa8](https://www.github.com/ipfs-shipyard/nft.storage/commit/a225fa8d1580bb7db79531bfd25c1e836103f60e))
-* set stream-channels=false for cluster add ([#304](https://www.github.com/ipfs-shipyard/nft.storage/issues/304)) ([f1121d0](https://www.github.com/ipfs-shipyard/nft.storage/commit/f1121d0e75b1750e6d1a5a851d5eeed8f04cb64b))
-
-## [2.3.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v2.2.2...api-v2.3.0) (2021-08-06)
+## [2.4.0](https://www.github.com/nftstorage/nft.storage/compare/api-v2.3.1...api-v2.4.0) (2021-08-27)
 
 
 ### Features
 
-* esbuild to build api and new tests ([#252](https://www.github.com/ipfs-shipyard/nft.storage/issues/252)) ([3cafc29](https://www.github.com/ipfs-shipyard/nft.storage/commit/3cafc29c0932b36421424827eca04323c26b22f9))
-* improvements to the setup ([#246](https://www.github.com/ipfs-shipyard/nft.storage/issues/246)) ([6a2501f](https://www.github.com/ipfs-shipyard/nft.storage/commit/6a2501f5c340af87c1571886961920280afec249))
-* update pw-test so its easier to run sw tests ([#240](https://www.github.com/ipfs-shipyard/nft.storage/issues/240)) ([5737ffc](https://www.github.com/ipfs-shipyard/nft.storage/commit/5737ffcb0323e20b31fdabdd305da075b92a9047))
+* remove custom multipart parser ([#336](https://www.github.com/nftstorage/nft.storage/issues/336)) ([029e71a](https://www.github.com/nftstorage/nft.storage/commit/029e71aefc1b152a080ffb5739e4f7c2565a1e57))
 
 
 ### Bug Fixes
 
-* niftysave pin job failures by adopting request timeouts ([#267](https://www.github.com/ipfs-shipyard/nft.storage/issues/267)) ([0bac638](https://www.github.com/ipfs-shipyard/nft.storage/commit/0bac6385ef0417a7a3453172bf3a3ed9e664f9e6))
-* temporarily locally add all uploads ([#286](https://www.github.com/ipfs-shipyard/nft.storage/issues/286)) ([f0443a5](https://www.github.com/ipfs-shipyard/nft.storage/commit/f0443a5b9baa0d6921be7ad8544ec4fd2c1e5218))
+* **api:** validate CID input for pins add and replace ([#314](https://www.github.com/nftstorage/nft.storage/issues/314)) ([dd5baca](https://www.github.com/nftstorage/nft.storage/commit/dd5bacac8207c715b097e7b1bc0555742c6b8488))
+* bad dag creation by store api ([#343](https://www.github.com/nftstorage/nft.storage/issues/343)) ([307e6cd](https://www.github.com/nftstorage/nft.storage/commit/307e6cd07e4b3587a404ea8fa367721f574d4e32))
+* temporarily set local=true for all uploads ([f637c86](https://www.github.com/nftstorage/nft.storage/commit/f637c86a569d1fc81a481574550e71bc02fae9ac))
 
-### [2.2.2](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v2.2.1...api-v2.2.2) (2021-07-06)
-
-
-### Bug Fixes
-
-* null deals ([#235](https://www.github.com/ipfs-shipyard/nft.storage/issues/235)) ([aad1259](https://www.github.com/ipfs-shipyard/nft.storage/commit/aad125902fe4f8e6b5144ed52e60be3988f24e1a))
-
-### [2.2.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v2.2.0...api-v2.2.1) (2021-06-22)
+### [2.3.2](https://www.github.com/nftstorage/nft.storage/compare/api-v2.3.1...api-v2.3.2) (2021-08-15)
 
 
 ### Bug Fixes
 
-* chunking issues ([#203](https://www.github.com/ipfs-shipyard/nft.storage/issues/203)) ([d990a20](https://www.github.com/ipfs-shipyard/nft.storage/commit/d990a207fd99aa74bde56a5d6b79e5027cf42287))
-* cluster status text for queued pin ([f0f9553](https://www.github.com/ipfs-shipyard/nft.storage/commit/f0f955305e9d65b6993f04a18b30673e5f8bc5e6))
-* initial pin status ([1a4d292](https://www.github.com/ipfs-shipyard/nft.storage/commit/1a4d29236bb4f76ec7689e4b9b6ba7f02072d8cd))
-* test expectations for new initial pin status ([ddaf11f](https://www.github.com/ipfs-shipyard/nft.storage/commit/ddaf11fd440324a0da8cc0eca80203e10cd233ed))
+* temporarily set local=true for all uploads ([f637c86](https://www.github.com/nftstorage/nft.storage/commit/f637c86a569d1fc81a481574550e71bc02fae9ac))
 
-## [2.2.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v2.1.0...api-v2.2.0) (2021-06-17)
+### [2.3.1](https://www.github.com/nftstorage/nft.storage/compare/api-v2.3.0...api-v2.3.1) (2021-08-11)
+
+
+### Bug Fixes
+
+* only local add files smaller then 2.5MiB ([#287](https://www.github.com/nftstorage/nft.storage/issues/287)) ([a225fa8](https://www.github.com/nftstorage/nft.storage/commit/a225fa8d1580bb7db79531bfd25c1e836103f60e))
+* set stream-channels=false for cluster add ([#304](https://www.github.com/nftstorage/nft.storage/issues/304)) ([f1121d0](https://www.github.com/nftstorage/nft.storage/commit/f1121d0e75b1750e6d1a5a851d5eeed8f04cb64b))
+
+## [2.3.0](https://www.github.com/nftstorage/nft.storage/compare/api-v2.2.2...api-v2.3.0) (2021-08-06)
 
 
 ### Features
 
-* support CAR file uploads ([#178](https://www.github.com/ipfs-shipyard/nft.storage/issues/178)) ([c7e5130](https://www.github.com/ipfs-shipyard/nft.storage/commit/c7e5130022ac1d0db13269582bdfa5e60d41bdea))
+* esbuild to build api and new tests ([#252](https://www.github.com/nftstorage/nft.storage/issues/252)) ([3cafc29](https://www.github.com/nftstorage/nft.storage/commit/3cafc29c0932b36421424827eca04323c26b22f9))
+* improvements to the setup ([#246](https://www.github.com/nftstorage/nft.storage/issues/246)) ([6a2501f](https://www.github.com/nftstorage/nft.storage/commit/6a2501f5c340af87c1571886961920280afec249))
+* update pw-test so its easier to run sw tests ([#240](https://www.github.com/nftstorage/nft.storage/issues/240)) ([5737ffc](https://www.github.com/nftstorage/nft.storage/commit/5737ffcb0323e20b31fdabdd305da075b92a9047))
 
-## [2.1.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v2.0.0...api-v2.1.0) (2021-05-26)
+
+### Bug Fixes
+
+* niftysave pin job failures by adopting request timeouts ([#267](https://www.github.com/nftstorage/nft.storage/issues/267)) ([0bac638](https://www.github.com/nftstorage/nft.storage/commit/0bac6385ef0417a7a3453172bf3a3ed9e664f9e6))
+* temporarily locally add all uploads ([#286](https://www.github.com/nftstorage/nft.storage/issues/286)) ([f0443a5](https://www.github.com/nftstorage/nft.storage/commit/f0443a5b9baa0d6921be7ad8544ec4fd2c1e5218))
+
+### [2.2.2](https://www.github.com/nftstorage/nft.storage/compare/api-v2.2.1...api-v2.2.2) (2021-07-06)
+
+
+### Bug Fixes
+
+* null deals ([#235](https://www.github.com/nftstorage/nft.storage/issues/235)) ([aad1259](https://www.github.com/nftstorage/nft.storage/commit/aad125902fe4f8e6b5144ed52e60be3988f24e1a))
+
+### [2.2.1](https://www.github.com/nftstorage/nft.storage/compare/api-v2.2.0...api-v2.2.1) (2021-06-22)
+
+
+### Bug Fixes
+
+* chunking issues ([#203](https://www.github.com/nftstorage/nft.storage/issues/203)) ([d990a20](https://www.github.com/nftstorage/nft.storage/commit/d990a207fd99aa74bde56a5d6b79e5027cf42287))
+* cluster status text for queued pin ([f0f9553](https://www.github.com/nftstorage/nft.storage/commit/f0f955305e9d65b6993f04a18b30673e5f8bc5e6))
+* initial pin status ([1a4d292](https://www.github.com/nftstorage/nft.storage/commit/1a4d29236bb4f76ec7689e4b9b6ba7f02072d8cd))
+* test expectations for new initial pin status ([ddaf11f](https://www.github.com/nftstorage/nft.storage/commit/ddaf11fd440324a0da8cc0eca80203e10cd233ed))
+
+## [2.2.0](https://www.github.com/nftstorage/nft.storage/compare/api-v2.1.0...api-v2.2.0) (2021-06-17)
 
 
 ### Features
 
-* cron job to ensure our pins are sent to Pinata ([#145](https://www.github.com/ipfs-shipyard/nft.storage/issues/145)) ([d071ca4](https://www.github.com/ipfs-shipyard/nft.storage/commit/d071ca4bb0921f9a663f8024a0e0e8a0fc7de0dd))
+* support CAR file uploads ([#178](https://www.github.com/nftstorage/nft.storage/issues/178)) ([c7e5130](https://www.github.com/nftstorage/nft.storage/commit/c7e5130022ac1d0db13269582bdfa5e60d41bdea))
 
-## [2.0.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v1.1.0...api-v2.0.0) (2021-05-18)
+## [2.1.0](https://www.github.com/nftstorage/nft.storage/compare/api-v2.0.0...api-v2.1.0) (2021-05-26)
+
+
+### Features
+
+* cron job to ensure our pins are sent to Pinata ([#145](https://www.github.com/nftstorage/nft.storage/issues/145)) ([d071ca4](https://www.github.com/nftstorage/nft.storage/commit/d071ca4bb0921f9a663f8024a0e0e8a0fc7de0dd))
+
+## [2.0.0](https://www.github.com/nftstorage/nft.storage/compare/api-v1.1.0...api-v2.0.0) (2021-05-18)
 
 
 ### ⚠ BREAKING CHANGES
@@ -181,29 +181,29 @@
 
 ### Bug Fixes
 
-* update cluster client for consistent hashes with IPFS ([5bc3c67](https://www.github.com/ipfs-shipyard/nft.storage/commit/5bc3c67b5310b54fd4fbc81bd313cccf21a68166))
+* update cluster client for consistent hashes with IPFS ([5bc3c67](https://www.github.com/nftstorage/nft.storage/commit/5bc3c67b5310b54fd4fbc81bd313cccf21a68166))
 
 
 ### Reverts
 
-* collection of followup metrics ([#133](https://www.github.com/ipfs-shipyard/nft.storage/issues/133)) ([b144224](https://www.github.com/ipfs-shipyard/nft.storage/commit/b144224ace1e67ba415206a6a3d9fcb071fbf878))
+* collection of followup metrics ([#133](https://www.github.com/nftstorage/nft.storage/issues/133)) ([b144224](https://www.github.com/nftstorage/nft.storage/commit/b144224ace1e67ba415206a6a3d9fcb071fbf878))
 
-## [1.1.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/api-v1.0.0...api-v1.1.0) (2021-05-17)
+## [1.1.0](https://www.github.com/nftstorage/nft.storage/compare/api-v1.0.0...api-v1.1.0) (2021-05-17)
 
 
 ### Features
 
-* **metrics:** collect and report total followups ([8d43e0f](https://www.github.com/ipfs-shipyard/nft.storage/commit/8d43e0fb6f4b6185df805330a4bd71d947e00586))
-* move metrics cron jobs to github actions ([#131](https://www.github.com/ipfs-shipyard/nft.storage/issues/131)) ([4ab3013](https://www.github.com/ipfs-shipyard/nft.storage/commit/4ab30134173764b82d1fb1887dafcb6e8f98ef9d))
+* **metrics:** collect and report total followups ([8d43e0f](https://www.github.com/nftstorage/nft.storage/commit/8d43e0fb6f4b6185df805330a4bd71d947e00586))
+* move metrics cron jobs to github actions ([#131](https://www.github.com/nftstorage/nft.storage/issues/131)) ([4ab3013](https://www.github.com/nftstorage/nft.storage/commit/4ab30134173764b82d1fb1887dafcb6e8f98ef9d))
 
 
 ### Bug Fixes
 
-* **metrics:** count followups not pins ([5e538d4](https://www.github.com/ipfs-shipyard/nft.storage/commit/5e538d4eb77d5a3c6793ce446ae311b737d7ab47))
+* **metrics:** count followups not pins ([5e538d4](https://www.github.com/nftstorage/nft.storage/commit/5e538d4eb77d5a3c6793ce446ae311b737d7ab47))
 
 ## 1.0.0 (2021-05-14)
 
 
 ### Bug Fixes
 
-* **api:** re-enable pinata in pin add ([ada4054](https://www.github.com/ipfs-shipyard/nft.storage/commit/ada405442be2e964f6149899869e266c2db41d60))
+* **api:** re-enable pinata in pin add ([ada4054](https://www.github.com/nftstorage/nft.storage/commit/ada405442be2e964f6149899869e266c2db41d60))

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,85 +1,85 @@
 # Changelog
 
-## [3.3.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/nft.storage-v3.2.2...nft.storage-v3.3.0) (2021-09-29)
+## [3.3.0](https://www.github.com/nftstorage/nft.storage/compare/nft.storage-v3.2.2...nft.storage-v3.3.0) (2021-09-29)
 
 
 ### Features
 
-* migrate database to postgres  ([#263](https://www.github.com/ipfs-shipyard/nft.storage/issues/263)) ([ff0c919](https://www.github.com/ipfs-shipyard/nft.storage/commit/ff0c919ad63f8452357ff5f23b3f1ecd24880c86))
+* migrate database to postgres  ([#263](https://www.github.com/nftstorage/nft.storage/issues/263)) ([ff0c919](https://www.github.com/nftstorage/nft.storage/commit/ff0c919ad63f8452357ff5f23b3f1ecd24880c86))
 
-### [3.2.2](https://www.github.com/ipfs-shipyard/nft.storage/compare/nft.storage-v3.2.1...nft.storage-v3.2.2) (2021-09-14)
-
-
-### Bug Fixes
-
-* capitalization ([d62e70b](https://www.github.com/ipfs-shipyard/nft.storage/commit/d62e70bf6bec1c0d6d9f33c74bb8404d8f746b5a))
-
-### [3.2.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/nft.storage-v3.2.0...nft.storage-v3.2.1) (2021-08-30)
+### [3.2.2](https://www.github.com/nftstorage/nft.storage/compare/nft.storage-v3.2.1...nft.storage-v3.2.2) (2021-09-14)
 
 
 ### Bug Fixes
 
-* **website:** fix api docs error ([#352](https://www.github.com/ipfs-shipyard/nft.storage/issues/352)) ([073d5aa](https://www.github.com/ipfs-shipyard/nft.storage/commit/073d5aa29b62de9253e1d362eaf1347b69929fa8)), closes [#348](https://www.github.com/ipfs-shipyard/nft.storage/issues/348)
+* capitalization ([d62e70b](https://www.github.com/nftstorage/nft.storage/commit/d62e70bf6bec1c0d6d9f33c74bb8404d8f746b5a))
 
-## [3.2.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/nft.storage-v3.1.3...nft.storage-v3.2.0) (2021-08-27)
+### [3.2.1](https://www.github.com/nftstorage/nft.storage/compare/nft.storage-v3.2.0...nft.storage-v3.2.1) (2021-08-30)
+
+
+### Bug Fixes
+
+* **website:** fix api docs error ([#352](https://www.github.com/nftstorage/nft.storage/issues/352)) ([073d5aa](https://www.github.com/nftstorage/nft.storage/commit/073d5aa29b62de9253e1d362eaf1347b69929fa8)), closes [#348](https://www.github.com/nftstorage/nft.storage/issues/348)
+
+## [3.2.0](https://www.github.com/nftstorage/nft.storage/compare/nft.storage-v3.1.3...nft.storage-v3.2.0) (2021-08-27)
 
 
 ### Features
 
-* remove custom multipart parser ([#336](https://www.github.com/ipfs-shipyard/nft.storage/issues/336)) ([029e71a](https://www.github.com/ipfs-shipyard/nft.storage/commit/029e71aefc1b152a080ffb5739e4f7c2565a1e57))
+* remove custom multipart parser ([#336](https://www.github.com/nftstorage/nft.storage/issues/336)) ([029e71a](https://www.github.com/nftstorage/nft.storage/commit/029e71aefc1b152a080ffb5739e4f7c2565a1e57))
 
 
 ### Bug Fixes
 
-* bad dag creation by store api ([#343](https://www.github.com/ipfs-shipyard/nft.storage/issues/343)) ([307e6cd](https://www.github.com/ipfs-shipyard/nft.storage/commit/307e6cd07e4b3587a404ea8fa367721f574d4e32))
-* Relaxes image/* requirement ([#334](https://www.github.com/ipfs-shipyard/nft.storage/issues/334)) ([f484297](https://www.github.com/ipfs-shipyard/nft.storage/commit/f484297123de4b5eca900831069dcd3fab2ac3b9))
+* bad dag creation by store api ([#343](https://www.github.com/nftstorage/nft.storage/issues/343)) ([307e6cd](https://www.github.com/nftstorage/nft.storage/commit/307e6cd07e4b3587a404ea8fa367721f574d4e32))
+* Relaxes image/* requirement ([#334](https://www.github.com/nftstorage/nft.storage/issues/334)) ([f484297](https://www.github.com/nftstorage/nft.storage/commit/f484297123de4b5eca900831069dcd3fab2ac3b9))
 
-### [3.1.3](https://www.github.com/ipfs-shipyard/nft.storage/compare/nft.storage-v3.1.2...nft.storage-v3.1.3) (2021-08-11)
-
-
-### Bug Fixes
-
-* **client:** fix back docs output ([628dafd](https://www.github.com/ipfs-shipyard/nft.storage/commit/628dafdb27923a2c794ff611577e5144fd97deaf))
-
-### [3.1.2](https://www.github.com/ipfs-shipyard/nft.storage/compare/nft.storage-v3.1.1...nft.storage-v3.1.2) (2021-08-11)
+### [3.1.3](https://www.github.com/nftstorage/nft.storage/compare/nft.storage-v3.1.2...nft.storage-v3.1.3) (2021-08-11)
 
 
 ### Bug Fixes
 
-* **client:** bump version for release ([3df7fcf](https://www.github.com/ipfs-shipyard/nft.storage/commit/3df7fcf8ef2949875eabacee21c8d9d60349b6a1))
+* **client:** fix back docs output ([628dafd](https://www.github.com/nftstorage/nft.storage/commit/628dafdb27923a2c794ff611577e5144fd97deaf))
 
-### [3.1.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/nft.storage-v3.1.0...nft.storage-v3.1.1) (2021-08-11)
+### [3.1.2](https://www.github.com/nftstorage/nft.storage/compare/nft.storage-v3.1.1...nft.storage-v3.1.2) (2021-08-11)
 
 
 ### Bug Fixes
 
-* **client:** dont publish everything ([8919819](https://www.github.com/ipfs-shipyard/nft.storage/commit/89198192508ed8cdd2084e312a5488348ea862af))
+* **client:** bump version for release ([3df7fcf](https://www.github.com/nftstorage/nft.storage/commit/3df7fcf8ef2949875eabacee21c8d9d60349b6a1))
 
-## [3.1.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/nft.storage-v3.0.1...nft.storage-v3.1.0) (2021-08-10)
+### [3.1.1](https://www.github.com/nftstorage/nft.storage/compare/nft.storage-v3.1.0...nft.storage-v3.1.1) (2021-08-11)
+
+
+### Bug Fixes
+
+* **client:** dont publish everything ([8919819](https://www.github.com/nftstorage/nft.storage/commit/89198192508ed8cdd2084e312a5488348ea862af))
+
+## [3.1.0](https://www.github.com/nftstorage/nft.storage/compare/nft.storage-v3.0.1...nft.storage-v3.1.0) (2021-08-10)
 
 
 ### Features
 
-* esbuild to build api and new tests ([#252](https://www.github.com/ipfs-shipyard/nft.storage/issues/252)) ([3cafc29](https://www.github.com/ipfs-shipyard/nft.storage/commit/3cafc29c0932b36421424827eca04323c26b22f9))
-* improvements to the setup ([#246](https://www.github.com/ipfs-shipyard/nft.storage/issues/246)) ([6a2501f](https://www.github.com/ipfs-shipyard/nft.storage/commit/6a2501f5c340af87c1571886961920280afec249))
-* update pw-test so its easier to run sw tests ([#240](https://www.github.com/ipfs-shipyard/nft.storage/issues/240)) ([5737ffc](https://www.github.com/ipfs-shipyard/nft.storage/commit/5737ffcb0323e20b31fdabdd305da075b92a9047))
+* esbuild to build api and new tests ([#252](https://www.github.com/nftstorage/nft.storage/issues/252)) ([3cafc29](https://www.github.com/nftstorage/nft.storage/commit/3cafc29c0932b36421424827eca04323c26b22f9))
+* improvements to the setup ([#246](https://www.github.com/nftstorage/nft.storage/issues/246)) ([6a2501f](https://www.github.com/nftstorage/nft.storage/commit/6a2501f5c340af87c1571886961920280afec249))
+* update pw-test so its easier to run sw tests ([#240](https://www.github.com/nftstorage/nft.storage/issues/240)) ([5737ffc](https://www.github.com/nftstorage/nft.storage/commit/5737ffcb0323e20b31fdabdd305da075b92a9047))
 
 
 ### Bug Fixes
 
-* broken links in client readme ([#294](https://www.github.com/ipfs-shipyard/nft.storage/issues/294)) ([afaa41e](https://www.github.com/ipfs-shipyard/nft.storage/commit/afaa41ef9398a4bf72cf98530b1035f7408577ba))
-* **client:** avoid single arg arrow fn ([a425ed2](https://www.github.com/ipfs-shipyard/nft.storage/commit/a425ed25a11b279f141c16d210782b8fbe47c6c4))
-* unblock niftysave ([#257](https://www.github.com/ipfs-shipyard/nft.storage/issues/257)) ([7fc56bd](https://www.github.com/ipfs-shipyard/nft.storage/commit/7fc56bdfbbbbe6a59a1ff7df9a42c81aad100635))
+* broken links in client readme ([#294](https://www.github.com/nftstorage/nft.storage/issues/294)) ([afaa41e](https://www.github.com/nftstorage/nft.storage/commit/afaa41ef9398a4bf72cf98530b1035f7408577ba))
+* **client:** avoid single arg arrow fn ([a425ed2](https://www.github.com/nftstorage/nft.storage/commit/a425ed25a11b279f141c16d210782b8fbe47c6c4))
+* unblock niftysave ([#257](https://www.github.com/nftstorage/nft.storage/issues/257)) ([7fc56bd](https://www.github.com/nftstorage/nft.storage/commit/7fc56bdfbbbbe6a59a1ff7df9a42c81aad100635))
 
-### [3.0.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/nft.storage-v3.0.0...nft.storage-v3.0.1) (2021-06-24)
+### [3.0.1](https://www.github.com/nftstorage/nft.storage/compare/nft.storage-v3.0.0...nft.storage-v3.0.1) (2021-06-24)
 
 
 ### Bug Fixes
 
-* add storeCar to client interface.ts ([#205](https://www.github.com/ipfs-shipyard/nft.storage/issues/205)) ([43c0bd3](https://www.github.com/ipfs-shipyard/nft.storage/commit/43c0bd3b888f28978e5ab3ab147393b2c3d24234))
-* the CarReader type is a collection of interfaces ([#214](https://www.github.com/ipfs-shipyard/nft.storage/issues/214)) ([09fd8cb](https://www.github.com/ipfs-shipyard/nft.storage/commit/09fd8cbb49dfb893fd480cc1f94b79afdc2fb769))
+* add storeCar to client interface.ts ([#205](https://www.github.com/nftstorage/nft.storage/issues/205)) ([43c0bd3](https://www.github.com/nftstorage/nft.storage/commit/43c0bd3b888f28978e5ab3ab147393b2c3d24234))
+* the CarReader type is a collection of interfaces ([#214](https://www.github.com/nftstorage/nft.storage/issues/214)) ([09fd8cb](https://www.github.com/nftstorage/nft.storage/commit/09fd8cbb49dfb893fd480cc1f94b79afdc2fb769))
 
-## [3.0.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/nft.storage-v2.1.1...nft.storage-v3.0.0) (2021-06-22)
+## [3.0.0](https://www.github.com/nftstorage/nft.storage/compare/nft.storage-v2.1.1...nft.storage-v3.0.0) (2021-06-22)
 
 
 ### ⚠ BREAKING CHANGES
@@ -88,31 +88,31 @@
 
 ### Features
 
-* car chunking client ([#199](https://www.github.com/ipfs-shipyard/nft.storage/issues/199)) ([fdfa8e9](https://www.github.com/ipfs-shipyard/nft.storage/commit/fdfa8e9cddcf144b5b643f005e28ed652bf44ca9)), closes [#173](https://www.github.com/ipfs-shipyard/nft.storage/issues/173)
-* deal data selector ([#198](https://www.github.com/ipfs-shipyard/nft.storage/issues/198)) ([7261c53](https://www.github.com/ipfs-shipyard/nft.storage/commit/7261c5350aff3f1ff991a8ff5c22d67722da6c5f)), closes [#192](https://www.github.com/ipfs-shipyard/nft.storage/issues/192)
+* car chunking client ([#199](https://www.github.com/nftstorage/nft.storage/issues/199)) ([fdfa8e9](https://www.github.com/nftstorage/nft.storage/commit/fdfa8e9cddcf144b5b643f005e28ed652bf44ca9)), closes [#173](https://www.github.com/nftstorage/nft.storage/issues/173)
+* deal data selector ([#198](https://www.github.com/nftstorage/nft.storage/issues/198)) ([7261c53](https://www.github.com/nftstorage/nft.storage/commit/7261c5350aff3f1ff991a8ff5c22d67722da6c5f)), closes [#192](https://www.github.com/nftstorage/nft.storage/issues/192)
 
 
 ### Bug Fixes
 
-* chunking issues ([#203](https://www.github.com/ipfs-shipyard/nft.storage/issues/203)) ([d990a20](https://www.github.com/ipfs-shipyard/nft.storage/commit/d990a207fd99aa74bde56a5d6b79e5027cf42287))
+* chunking issues ([#203](https://www.github.com/nftstorage/nft.storage/issues/203)) ([d990a20](https://www.github.com/nftstorage/nft.storage/commit/d990a207fd99aa74bde56a5d6b79e5027cf42287))
 
-### [2.1.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/nft.storage-v2.1.0...nft.storage-v2.1.1) (2021-06-18)
+### [2.1.1](https://www.github.com/nftstorage/nft.storage/compare/nft.storage-v2.1.0...nft.storage-v2.1.1) (2021-06-18)
 
 
 ### Bug Fixes
 
-* car upload example ([#197](https://www.github.com/ipfs-shipyard/nft.storage/issues/197)) ([c6b1a68](https://www.github.com/ipfs-shipyard/nft.storage/commit/c6b1a68e643390464b3b46a2707a6430c3ce4f74))
-* **client:** npm lifecycle build command ([#194](https://www.github.com/ipfs-shipyard/nft.storage/issues/194)) ([41138df](https://www.github.com/ipfs-shipyard/nft.storage/commit/41138dfe5fe7308eb2b1dd4f9acd82de3a11f63d))
-* misc docs issues ([#190](https://www.github.com/ipfs-shipyard/nft.storage/issues/190)) ([04e9840](https://www.github.com/ipfs-shipyard/nft.storage/commit/04e9840e35903a6738b0e947c150047ce521f912))
+* car upload example ([#197](https://www.github.com/nftstorage/nft.storage/issues/197)) ([c6b1a68](https://www.github.com/nftstorage/nft.storage/commit/c6b1a68e643390464b3b46a2707a6430c3ce4f74))
+* **client:** npm lifecycle build command ([#194](https://www.github.com/nftstorage/nft.storage/issues/194)) ([41138df](https://www.github.com/nftstorage/nft.storage/commit/41138dfe5fe7308eb2b1dd4f9acd82de3a11f63d))
+* misc docs issues ([#190](https://www.github.com/nftstorage/nft.storage/issues/190)) ([04e9840](https://www.github.com/nftstorage/nft.storage/commit/04e9840e35903a6738b0e947c150047ce521f912))
 
-## [2.1.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/nft.storage-v2.0.0...nft.storage-v2.1.0) (2021-06-15)
+## [2.1.0](https://www.github.com/nftstorage/nft.storage/compare/nft.storage-v2.0.0...nft.storage-v2.1.0) (2021-06-15)
 
 
 ### Features
 
-* support CAR file uploads ([#178](https://www.github.com/ipfs-shipyard/nft.storage/issues/178)) ([c7e5130](https://www.github.com/ipfs-shipyard/nft.storage/commit/c7e5130022ac1d0db13269582bdfa5e60d41bdea))
+* support CAR file uploads ([#178](https://www.github.com/nftstorage/nft.storage/issues/178)) ([c7e5130](https://www.github.com/nftstorage/nft.storage/commit/c7e5130022ac1d0db13269582bdfa5e60d41bdea))
 
-## [2.0.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/nft.storage-v1.4.0...nft.storage-v2.0.0) (2021-06-01)
+## [2.0.0](https://www.github.com/nftstorage/nft.storage/compare/nft.storage-v1.4.0...nft.storage-v2.0.0) (2021-06-01)
 
 
 ### ⚠ BREAKING CHANGES
@@ -121,31 +121,31 @@
 
 ### Features
 
-* add ipfs URL to gateway URL converter ([#161](https://www.github.com/ipfs-shipyard/nft.storage/issues/161)) ([f115cd8](https://www.github.com/ipfs-shipyard/nft.storage/commit/f115cd8964bc565fc1a3313fc8d2fb3a392dd0ac))
+* add ipfs URL to gateway URL converter ([#161](https://www.github.com/nftstorage/nft.storage/issues/161)) ([f115cd8](https://www.github.com/nftstorage/nft.storage/commit/f115cd8964bc565fc1a3313fc8d2fb3a392dd0ac))
 
-## [1.4.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/nft.storage-v1.3.1...nft.storage-v1.4.0) (2021-05-26)
+## [1.4.0](https://www.github.com/nftstorage/nft.storage/compare/nft.storage-v1.3.1...nft.storage-v1.4.0) (2021-05-26)
 
 
 ### Features
 
-* allow extensions to ERC-1155 metadata ([#146](https://www.github.com/ipfs-shipyard/nft.storage/issues/146)) ([f45cf9f](https://www.github.com/ipfs-shipyard/nft.storage/commit/f45cf9f32a1143853c533a1a016b8f9443c666dd))
+* allow extensions to ERC-1155 metadata ([#146](https://www.github.com/nftstorage/nft.storage/issues/146)) ([f45cf9f](https://www.github.com/nftstorage/nft.storage/commit/f45cf9f32a1143853c533a1a016b8f9443c666dd))
 
-### [1.3.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/nft.storage-v1.3.0...nft.storage-v1.3.1) (2021-05-14)
+### [1.3.1](https://www.github.com/nftstorage/nft.storage/compare/nft.storage-v1.3.0...nft.storage-v1.3.1) (2021-05-14)
 
 
 ### Bug Fixes
 
-* **client:** fix publish ([052fee0](https://www.github.com/ipfs-shipyard/nft.storage/commit/052fee0661256c05378470a2276bb46e99ccbe2d))
+* **client:** fix publish ([052fee0](https://www.github.com/nftstorage/nft.storage/commit/052fee0661256c05378470a2276bb46e99ccbe2d))
 
 ## 1.3.0 (2021-05-14)
 
 
 ### Bug Fixes
 
-* **client:** let try auto publish ([46d0e28](https://www.github.com/ipfs-shipyard/nft.storage/commit/46d0e284abb8ae4da53e87530ac908e6c776d141))
+* **client:** let try auto publish ([46d0e28](https://www.github.com/nftstorage/nft.storage/commit/46d0e284abb8ae4da53e87530ac908e6c776d141))
 
 
 ### Miscellaneous Chores
 
-* **client:** release bump ([23c2457](https://www.github.com/ipfs-shipyard/nft.storage/commit/23c2457bee1a8ba967934e95f2cdaa0228c66e6b))
-* fix client version ([70ce7e9](https://www.github.com/ipfs-shipyard/nft.storage/commit/70ce7e94b4fe3a2fdba7146a5c1ac7cb241c2694))
+* **client:** release bump ([23c2457](https://www.github.com/nftstorage/nft.storage/commit/23c2457bee1a8ba967934e95f2cdaa0228c66e6b))
+* fix client version ([70ce7e9](https://www.github.com/nftstorage/nft.storage/commit/70ce7e94b4fe3a2fdba7146a5c1ac7cb241c2694))

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -46,22 +46,22 @@ console.log(metadata.url)
 // ipfs://bafyreib4pff766vhpbxbhjbqqnsh5emeznvujayjj4z2iu533cprgbz23m/metadata.json
 ```
 
-For more examples please see the [API documentation](https://ipfs-shipyard.github.io/nft.storage/client/) or the [examples directory in the project repository][examples directory], which contains sample projects for both [browsers][examples.browser] and [Node.js][examples.node].
+For more examples please see the [API documentation](https://nftstorage.github.io/nft.storage/client/) or the [examples directory in the project repository][examples directory], which contains sample projects for both [browsers][examples.browser] and [Node.js][examples.node].
 
 [raw http api]: https://nft.storage/#api-docs
 [node.js]: https://nodejs.org/
-[api documentation]: https://ipfs-shipyard.github.io/nft.storage/client/
-[examples directory]: https://github.com/ipfs-shipyard/nft.storage/tree/main/packages/client/examples
-[examples.node]: https://github.com/ipfs-shipyard/nft.storage/tree/main/packages/client/examples/node.js
-[examples.browser]: https://github.com/ipfs-shipyard/nft.storage/tree/main/packages/client/examples/browser
-[ci.icon]: https://github.com/ipfs-shipyard/nft.storage/actions/workflows/client.yml/badge.svg
+[api documentation]: https://nftstorage.github.io/nft.storage/client/
+[examples directory]: https://github.com/nftstorage/nft.storage/tree/main/packages/client/examples
+[examples.node]: https://github.com/nftstorage/nft.storage/tree/main/packages/client/examples/node.js
+[examples.browser]: https://github.com/nftstorage/nft.storage/tree/main/packages/client/examples/browser
+[ci.icon]: https://github.com/nftstorage/nft.storage/actions/workflows/client.yml/badge.svg
 [version.icon]: https://img.shields.io/npm/v/nft.storage.svg
 [package.url]: https://npmjs.org/package/nft.storage
 [prettier.icon]: https://img.shields.io/badge/styled_with-prettier-ff69b4.svg
 [prettier.url]: https://github.com/prettier/prettier
 [size.icon]: https://badgen.net/bundlephobia/minzip/nft.storage
 [size.url]: https://bundlephobia.com/result?p=nft.storage
-[deps.icon]: https://status.david-dm.org/gh/ipfs-shipyard/nft.storage.svg?path=packages/client
-[deps.url]: https://david-dm.org/ipfs-shipyard/nft.storage?path=packages/client
-[cov.icon]: https://codecov.io/gh/ipfs-shipyard/nft.storage/branch/main/graph/badge.svg?token=dU5oWrlqHF
-[cov.url]: https://codecov.io/gh/ipfs-shipyard/nft.storage
+[deps.icon]: https://status.david-dm.org/gh/nftstorage/nft.storage.svg?path=packages/client
+[deps.url]: https://david-dm.org/nftstorage/nft.storage?path=packages/client
+[cov.icon]: https://codecov.io/gh/nftstorage/nft.storage/branch/main/graph/badge.svg?token=dU5oWrlqHF
+[cov.url]: https://codecov.io/gh/nftstorage/nft.storage

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -73,11 +73,11 @@
     "typedoc": "0.21.4",
     "uvu": "0.5.1"
   },
-  "homepage": "https://github.com/ipfs-shipyard/nft.storage/tree/main/packages/client",
-  "bugs": "https://github.com/ipfs-shipyard/nft.storage/issues",
+  "homepage": "https://github.com/nftstorage/nft.storage/tree/main/packages/client",
+  "bugs": "https://github.com/nftstorage/nft.storage/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ipfs-shipyard/nft.storage.git",
+    "url": "https://github.com/nftstorage/nft.storage.git",
     "directory": "packages/client"
   }
 }

--- a/packages/cron/CHANGELOG.md
+++ b/packages/cron/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## [2.1.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/cron-v2.0.0...cron-v2.1.0) (2021-07-13)
+## [2.1.0](https://www.github.com/nftstorage/nft.storage/compare/cron-v2.0.0...cron-v2.1.0) (2021-07-13)
 
 
 ### Features
 
-* improvements to the setup ([#246](https://www.github.com/ipfs-shipyard/nft.storage/issues/246)) ([6a2501f](https://www.github.com/ipfs-shipyard/nft.storage/commit/6a2501f5c340af87c1571886961920280afec249))
+* improvements to the setup ([#246](https://www.github.com/nftstorage/nft.storage/issues/246)) ([6a2501f](https://www.github.com/nftstorage/nft.storage/commit/6a2501f5c340af87c1571886961920280afec249))
 
-## [2.0.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/cron-v1.1.0...cron-v2.0.0) (2021-07-06)
+## [2.0.0](https://www.github.com/nftstorage/nft.storage/compare/cron-v1.1.0...cron-v2.0.0) (2021-07-06)
 
 
 ### ⚠ BREAKING CHANGES
@@ -16,41 +16,41 @@
 
 ### Features
 
-* add ipfs URL to gateway URL converter ([#161](https://www.github.com/ipfs-shipyard/nft.storage/issues/161)) ([f115cd8](https://www.github.com/ipfs-shipyard/nft.storage/commit/f115cd8964bc565fc1a3313fc8d2fb3a392dd0ac))
+* add ipfs URL to gateway URL converter ([#161](https://www.github.com/nftstorage/nft.storage/issues/161)) ([f115cd8](https://www.github.com/nftstorage/nft.storage/commit/f115cd8964bc565fc1a3313fc8d2fb3a392dd0ac))
 
 
 ### Bug Fixes
 
-* chunking issues ([#203](https://www.github.com/ipfs-shipyard/nft.storage/issues/203)) ([d990a20](https://www.github.com/ipfs-shipyard/nft.storage/commit/d990a207fd99aa74bde56a5d6b79e5027cf42287))
-* cluster status text for queued pin ([f0f9553](https://www.github.com/ipfs-shipyard/nft.storage/commit/f0f955305e9d65b6993f04a18b30673e5f8bc5e6))
-* increase DAG size request timeout ([d833ab6](https://www.github.com/ipfs-shipyard/nft.storage/commit/d833ab631b865e9406b6434769d934f8c1bde946))
+* chunking issues ([#203](https://www.github.com/nftstorage/nft.storage/issues/203)) ([d990a20](https://www.github.com/nftstorage/nft.storage/commit/d990a207fd99aa74bde56a5d6b79e5027cf42287))
+* cluster status text for queued pin ([f0f9553](https://www.github.com/nftstorage/nft.storage/commit/f0f955305e9d65b6993f04a18b30673e5f8bc5e6))
+* increase DAG size request timeout ([d833ab6](https://www.github.com/nftstorage/nft.storage/commit/d833ab631b865e9406b6434769d934f8c1bde946))
 
-## [1.1.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/cron-v1.0.1...cron-v1.1.0) (2021-05-26)
+## [1.1.0](https://www.github.com/nftstorage/nft.storage/compare/cron-v1.0.1...cron-v1.1.0) (2021-05-26)
 
 
 ### Features
 
-* add find-user tool ([45dcdc5](https://www.github.com/ipfs-shipyard/nft.storage/commit/45dcdc55b552d1b6ba8f3ba1db9f6a263fcf7e2f))
-* cron job to ensure our pins are sent to Pinata ([#145](https://www.github.com/ipfs-shipyard/nft.storage/issues/145)) ([d071ca4](https://www.github.com/ipfs-shipyard/nft.storage/commit/d071ca4bb0921f9a663f8024a0e0e8a0fc7de0dd))
+* add find-user tool ([45dcdc5](https://www.github.com/nftstorage/nft.storage/commit/45dcdc55b552d1b6ba8f3ba1db9f6a263fcf7e2f))
+* cron job to ensure our pins are sent to Pinata ([#145](https://www.github.com/nftstorage/nft.storage/issues/145)) ([d071ca4](https://www.github.com/nftstorage/nft.storage/commit/d071ca4bb0921f9a663f8024a0e0e8a0fc7de0dd))
 
 
 ### Bug Fixes
 
-* guard against null size ([52a97af](https://www.github.com/ipfs-shipyard/nft.storage/commit/52a97af6a2cf2be4b8dee1de946f05179b361358))
-* increase retry timeout ([7ca6582](https://www.github.com/ipfs-shipyard/nft.storage/commit/7ca6582f0fd9ce07a59c7766fc3c907fe3d1fbf0))
-* log line labels ([f4a1f89](https://www.github.com/ipfs-shipyard/nft.storage/commit/f4a1f890f4820aae92d2fcecd630ad972658e4c9))
-* pin limiter to v2.0.1 ([107c946](https://www.github.com/ipfs-shipyard/nft.storage/commit/107c9462fc6f9118e8b390c6cbc18ef0bc55f18c))
+* guard against null size ([52a97af](https://www.github.com/nftstorage/nft.storage/commit/52a97af6a2cf2be4b8dee1de946f05179b361358))
+* increase retry timeout ([7ca6582](https://www.github.com/nftstorage/nft.storage/commit/7ca6582f0fd9ce07a59c7766fc3c907fe3d1fbf0))
+* log line labels ([f4a1f89](https://www.github.com/nftstorage/nft.storage/commit/f4a1f890f4820aae92d2fcecd630ad972658e4c9))
+* pin limiter to v2.0.1 ([107c946](https://www.github.com/nftstorage/nft.storage/commit/107c9462fc6f9118e8b390c6cbc18ef0bc55f18c))
 
-### [1.0.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/cron-v1.0.0...cron-v1.0.1) (2021-05-18)
+### [1.0.1](https://www.github.com/nftstorage/nft.storage/compare/cron-v1.0.0...cron-v1.0.1) (2021-05-18)
 
 
 ### Reverts
 
-* collection of followup metrics ([#133](https://www.github.com/ipfs-shipyard/nft.storage/issues/133)) ([b144224](https://www.github.com/ipfs-shipyard/nft.storage/commit/b144224ace1e67ba415206a6a3d9fcb071fbf878))
+* collection of followup metrics ([#133](https://www.github.com/nftstorage/nft.storage/issues/133)) ([b144224](https://www.github.com/nftstorage/nft.storage/commit/b144224ace1e67ba415206a6a3d9fcb071fbf878))
 
 ## 1.0.0 (2021-05-17)
 
 
 ### Features
 
-* move metrics cron jobs to github actions ([#131](https://www.github.com/ipfs-shipyard/nft.storage/issues/131)) ([4ab3013](https://www.github.com/ipfs-shipyard/nft.storage/commit/4ab30134173764b82d1fb1887dafcb6e8f98ef9d))
+* move metrics cron jobs to github actions ([#131](https://www.github.com/nftstorage/nft.storage/issues/131)) ([4ab3013](https://www.github.com/nftstorage/nft.storage/commit/4ab30134173764b82d1fb1887dafcb6e8f98ef9d))

--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Features
 
-* enable niftysave ([#238](https://www.github.com/ipfs-shipyard/nft.storage/issues/238)) ([61a30ef](https://www.github.com/ipfs-shipyard/nft.storage/commit/61a30efea3879ec38ba97d0e5b4d300182b50908))
-* improvements to the setup ([#246](https://www.github.com/ipfs-shipyard/nft.storage/issues/246)) ([6a2501f](https://www.github.com/ipfs-shipyard/nft.storage/commit/6a2501f5c340af87c1571886961920280afec249))
-* migrate niftysave database ([#228](https://www.github.com/ipfs-shipyard/nft.storage/issues/228)) ([a0e2a6d](https://www.github.com/ipfs-shipyard/nft.storage/commit/a0e2a6d8f4a3fcc2135cb25d7d19d6dbd86c891b))
-* update pw-test so its easier to run sw tests ([#240](https://www.github.com/ipfs-shipyard/nft.storage/issues/240)) ([5737ffc](https://www.github.com/ipfs-shipyard/nft.storage/commit/5737ffcb0323e20b31fdabdd305da075b92a9047))
+* enable niftysave ([#238](https://www.github.com/nftstorage/nft.storage/issues/238)) ([61a30ef](https://www.github.com/nftstorage/nft.storage/commit/61a30efea3879ec38ba97d0e5b4d300182b50908))
+* improvements to the setup ([#246](https://www.github.com/nftstorage/nft.storage/issues/246)) ([6a2501f](https://www.github.com/nftstorage/nft.storage/commit/6a2501f5c340af87c1571886961920280afec249))
+* migrate niftysave database ([#228](https://www.github.com/nftstorage/nft.storage/issues/228)) ([a0e2a6d](https://www.github.com/nftstorage/nft.storage/commit/a0e2a6d8f4a3fcc2135cb25d7d19d6dbd86c891b))
+* update pw-test so its easier to run sw tests ([#240](https://www.github.com/nftstorage/nft.storage/issues/240)) ([5737ffc](https://www.github.com/nftstorage/nft.storage/commit/5737ffcb0323e20b31fdabdd305da075b92a9047))

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -30,9 +30,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ipfs-shipyard/nft.storage.git",
+    "url": "https://github.com/nftstorage/nft.storage.git",
     "directory": "database"
   },
-  "homepage": "https://github.com/ipfs-shipyard/nft.storage/tree/main/database",
-  "bugs": "https://github.com/ipfs-shipyard/nft.storage/issues"
+  "homepage": "https://github.com/nftstorage/nft.storage/tree/main/database",
+  "bugs": "https://github.com/nftstorage/nft.storage/issues"
 }

--- a/packages/database_v2/migrations/default/1633723764300_alter_pin_table/up.sql
+++ b/packages/database_v2/migrations/default/1633723764300_alter_pin_table/up.sql
@@ -5,7 +5,7 @@ ALTER TABLE pin ADD CONSTRAINT pin_content_cid_service_key UNIQUE (content_cid,
                                                                    service);
 
 -- Add aditional value used as per
--- https://github.com/ipfs-shipyard/nft.storage/blob/08654e9e950c4784746ab23873bfe2afe835c3fb/packages/api/db/tables.sql#L21
+-- https://github.com/nftstorage/nft.storage/blob/08654e9e950c4784746ab23873bfe2afe835c3fb/packages/api/db/tables.sql#L21
 
 ALTER TYPE pin_service ADD VALUE 'IpfsCluster2';
 

--- a/packages/migrations/001-nfts-index.js
+++ b/packages/migrations/001-nfts-index.js
@@ -15,7 +15,7 @@ dotenv.config()
 const FAR_FUTURE = new Date('3000-01-01T00:00:00.000Z').getTime()
 const PAD_LEN = FAR_FUTURE.toString().length
 
-// TODO: can be imported when https://github.com/ipfs-shipyard/nft.storage/pull/65 is merged
+// TODO: can be imported when https://github.com/nftstorage/nft.storage/pull/65 is merged
 function encodeIndexKey({ user, created, cid }) {
   const ts = (FAR_FUTURE - created.getTime()).toString().padStart(PAD_LEN, '0')
   return `${user.sub}:${ts}:${cid}`

--- a/packages/migrations/004-reindex-nfts.js
+++ b/packages/migrations/004-reindex-nfts.js
@@ -12,7 +12,7 @@ dotenv.config()
 const FAR_FUTURE = new Date('3000-01-01T00:00:00.000Z').getTime()
 const PAD_LEN = FAR_FUTURE.toString().length
 
-// TODO: can be imported when https://github.com/ipfs-shipyard/nft.storage/pull/65 is merged
+// TODO: can be imported when https://github.com/nftstorage/nft.storage/pull/65 is merged
 function encodeIndexKey({ user, created, cid }) {
   const ts = (FAR_FUTURE - created.getTime()).toString().padStart(PAD_LEN, '0')
   return `${user.sub}:${ts}:${cid}`

--- a/packages/migrations/CHANGELOG.md
+++ b/packages/migrations/CHANGELOG.md
@@ -1,16 +1,16 @@
 # Changelog
 
-### [1.0.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/migrations-v1.0.0...migrations-v1.0.1) (2021-06-17)
+### [1.0.1](https://www.github.com/nftstorage/nft.storage/compare/migrations-v1.0.0...migrations-v1.0.1) (2021-06-17)
 
 
 ### Bug Fixes
 
-* remove test code ([91fa46c](https://www.github.com/ipfs-shipyard/nft.storage/commit/91fa46c761a8677924bf7e238d3534624c37bcc7))
+* remove test code ([91fa46c](https://www.github.com/nftstorage/nft.storage/commit/91fa46c761a8677924bf7e238d3534624c37bcc7))
 
 ## 1.0.0 (2021-05-26)
 
 
 ### Features
 
-* add find-user tool ([45dcdc5](https://www.github.com/ipfs-shipyard/nft.storage/commit/45dcdc55b552d1b6ba8f3ba1db9f6a263fcf7e2f))
-* cron job to ensure our pins are sent to Pinata ([#145](https://www.github.com/ipfs-shipyard/nft.storage/issues/145)) ([d071ca4](https://www.github.com/ipfs-shipyard/nft.storage/commit/d071ca4bb0921f9a663f8024a0e0e8a0fc7de0dd))
+* add find-user tool ([45dcdc5](https://www.github.com/nftstorage/nft.storage/commit/45dcdc55b552d1b6ba8f3ba1db9f6a263fcf7e2f))
+* cron job to ensure our pins are sent to Pinata ([#145](https://www.github.com/nftstorage/nft.storage/issues/145)) ([d071ca4](https://www.github.com/nftstorage/nft.storage/commit/d071ca4bb0921f9a663f8024a0e0e8a0fc7de0dd))

--- a/packages/niftysave/CHANGELOG.md
+++ b/packages/niftysave/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Features
 
-* enable niftysave ([#238](https://www.github.com/ipfs-shipyard/nft.storage/issues/238)) ([61a30ef](https://www.github.com/ipfs-shipyard/nft.storage/commit/61a30efea3879ec38ba97d0e5b4d300182b50908))
-* improvements to the setup ([#246](https://www.github.com/ipfs-shipyard/nft.storage/issues/246)) ([6a2501f](https://www.github.com/ipfs-shipyard/nft.storage/commit/6a2501f5c340af87c1571886961920280afec249))
-* migrate niftysave ([#229](https://www.github.com/ipfs-shipyard/nft.storage/issues/229)) ([98d83ea](https://www.github.com/ipfs-shipyard/nft.storage/commit/98d83ea00a26363632ddaa33ab632831218f5a1e))
-* update pw-test so its easier to run sw tests ([#240](https://www.github.com/ipfs-shipyard/nft.storage/issues/240)) ([5737ffc](https://www.github.com/ipfs-shipyard/nft.storage/commit/5737ffcb0323e20b31fdabdd305da075b92a9047))
+* enable niftysave ([#238](https://www.github.com/nftstorage/nft.storage/issues/238)) ([61a30ef](https://www.github.com/nftstorage/nft.storage/commit/61a30efea3879ec38ba97d0e5b4d300182b50908))
+* improvements to the setup ([#246](https://www.github.com/nftstorage/nft.storage/issues/246)) ([6a2501f](https://www.github.com/nftstorage/nft.storage/commit/6a2501f5c340af87c1571886961920280afec249))
+* migrate niftysave ([#229](https://www.github.com/nftstorage/nft.storage/issues/229)) ([98d83ea](https://www.github.com/nftstorage/nft.storage/commit/98d83ea00a26363632ddaa33ab632831218f5a1e))
+* update pw-test so its easier to run sw tests ([#240](https://www.github.com/nftstorage/nft.storage/issues/240)) ([5737ffc](https://www.github.com/nftstorage/nft.storage/commit/5737ffcb0323e20b31fdabdd305da075b92a9047))

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,37 +1,37 @@
 # Changelog
 
-## [1.2.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/tools-v1.1.0...tools-v1.2.0) (2021-07-13)
+## [1.2.0](https://www.github.com/nftstorage/nft.storage/compare/tools-v1.1.0...tools-v1.2.0) (2021-07-13)
 
 
 ### Features
 
-* improvements to the setup ([#246](https://www.github.com/ipfs-shipyard/nft.storage/issues/246)) ([6a2501f](https://www.github.com/ipfs-shipyard/nft.storage/commit/6a2501f5c340af87c1571886961920280afec249))
-* update pw-test so its easier to run sw tests ([#240](https://www.github.com/ipfs-shipyard/nft.storage/issues/240)) ([5737ffc](https://www.github.com/ipfs-shipyard/nft.storage/commit/5737ffcb0323e20b31fdabdd305da075b92a9047))
+* improvements to the setup ([#246](https://www.github.com/nftstorage/nft.storage/issues/246)) ([6a2501f](https://www.github.com/nftstorage/nft.storage/commit/6a2501f5c340af87c1571886961920280afec249))
+* update pw-test so its easier to run sw tests ([#240](https://www.github.com/nftstorage/nft.storage/issues/240)) ([5737ffc](https://www.github.com/nftstorage/nft.storage/commit/5737ffcb0323e20b31fdabdd305da075b92a9047))
 
-## [1.1.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/tools-v1.0.2...tools-v1.1.0) (2021-07-07)
+## [1.1.0](https://www.github.com/nftstorage/nft.storage/compare/tools-v1.0.2...tools-v1.1.0) (2021-07-07)
 
 
 ### Features
 
-* cf sync pipeline ([#201](https://www.github.com/ipfs-shipyard/nft.storage/issues/201)) ([50a3b3f](https://www.github.com/ipfs-shipyard/nft.storage/commit/50a3b3f09ddb93cf10d4fb0cd3ccbd202156889a))
+* cf sync pipeline ([#201](https://www.github.com/nftstorage/nft.storage/issues/201)) ([50a3b3f](https://www.github.com/nftstorage/nft.storage/commit/50a3b3f09ddb93cf10d4fb0cd3ccbd202156889a))
 
-### [1.0.2](https://www.github.com/ipfs-shipyard/nft.storage/compare/tools-v1.0.1...tools-v1.0.2) (2021-05-14)
-
-
-### Bug Fixes
-
-* **tools:** dont filter by package ([6b04db3](https://www.github.com/ipfs-shipyard/nft.storage/commit/6b04db36f00e9ac18b2d479fa4db36032e087157))
-
-### [1.0.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/tools-v1.0.0...tools-v1.0.1) (2021-05-14)
+### [1.0.2](https://www.github.com/nftstorage/nft.storage/compare/tools-v1.0.1...tools-v1.0.2) (2021-05-14)
 
 
 ### Bug Fixes
 
-* **tools:** fix deploy-website command to use proper ref ([3350046](https://www.github.com/ipfs-shipyard/nft.storage/commit/3350046f7d302ba8e8967a4b2e6923cd508634bd))
+* **tools:** dont filter by package ([6b04db3](https://www.github.com/nftstorage/nft.storage/commit/6b04db36f00e9ac18b2d479fa4db36032e087157))
+
+### [1.0.1](https://www.github.com/nftstorage/nft.storage/compare/tools-v1.0.0...tools-v1.0.1) (2021-05-14)
+
+
+### Bug Fixes
+
+* **tools:** fix deploy-website command to use proper ref ([3350046](https://www.github.com/nftstorage/nft.storage/commit/3350046f7d302ba8e8967a4b2e6923cd508634bd))
 
 ## 1.0.0 (2021-05-14)
 
 
 ### Bug Fixes
 
-* **tools:** fix cli exit codes ([16fa057](https://www.github.com/ipfs-shipyard/nft.storage/commit/16fa0574c8bd35553c6254b06ffdfd457f3b5474))
+* **tools:** fix cli exit codes ([16fa057](https://www.github.com/nftstorage/nft.storage/commit/16fa0574c8bd35553c6254b06ffdfd457f3b5474))

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -1,174 +1,174 @@
 # Changelog
 
-### [1.8.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.8.0...website-v1.8.1) (2021-10-14)
+### [1.8.1](https://www.github.com/nftstorage/nft.storage/compare/website-v1.8.0...website-v1.8.1) (2021-10-14)
 
 
 ### Bug Fixes
 
-* maintenance banner padding and button text color ([#609](https://www.github.com/ipfs-shipyard/nft.storage/issues/609)) ([c04e2f7](https://www.github.com/ipfs-shipyard/nft.storage/commit/c04e2f73d38b72d106a50d090ad0e8fa9e1f9484)), closes [#569](https://www.github.com/ipfs-shipyard/nft.storage/issues/569)
+* maintenance banner padding and button text color ([#609](https://www.github.com/nftstorage/nft.storage/issues/609)) ([c04e2f7](https://www.github.com/nftstorage/nft.storage/commit/c04e2f73d38b72d106a50d090ad0e8fa9e1f9484)), closes [#569](https://www.github.com/nftstorage/nft.storage/issues/569)
 
-## [1.8.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.7.0...website-v1.8.0) (2021-10-14)
+## [1.8.0](https://www.github.com/nftstorage/nft.storage/compare/website-v1.7.0...website-v1.8.0) (2021-10-14)
 
 
 ### Features
 
-* update long term vision faq ([#600](https://www.github.com/ipfs-shipyard/nft.storage/issues/600)) ([564e77f](https://www.github.com/ipfs-shipyard/nft.storage/commit/564e77fd5ba1f3ec30d4d9984424d983742e0343))
+* update long term vision faq ([#600](https://www.github.com/nftstorage/nft.storage/issues/600)) ([564e77f](https://www.github.com/nftstorage/nft.storage/commit/564e77fd5ba1f3ec30d4d9984424d983742e0343))
 
 
 ### Bug Fixes
 
-* add more vertical space between FAQ items ([6958970](https://www.github.com/ipfs-shipyard/nft.storage/commit/6958970c5016cfd3bc5a8e1286ba2022d05a2988))
-* temporarily add querystring-browser to fix UI build issue ([fe7bd43](https://www.github.com/ipfs-shipyard/nft.storage/commit/fe7bd437deff3add6720d26e540df36a3557070c))
+* add more vertical space between FAQ items ([6958970](https://www.github.com/nftstorage/nft.storage/commit/6958970c5016cfd3bc5a8e1286ba2022d05a2988))
+* temporarily add querystring-browser to fix UI build issue ([fe7bd43](https://www.github.com/nftstorage/nft.storage/commit/fe7bd437deff3add6720d26e540df36a3557070c))
 
 
 ### Changes
 
-* move v1 to root (minimal changes) ([#534](https://www.github.com/ipfs-shipyard/nft.storage/issues/534)) ([c60cf6c](https://www.github.com/ipfs-shipyard/nft.storage/commit/c60cf6c06dc5812f980152fcb9b451a84cf9aba7))
-* prettier and LF line endings (no functional changes) ([#580](https://www.github.com/ipfs-shipyard/nft.storage/issues/580)) ([e1e5bc4](https://www.github.com/ipfs-shipyard/nft.storage/commit/e1e5bc47e5ae112a0775a25b275691a818665f37))
+* move v1 to root (minimal changes) ([#534](https://www.github.com/nftstorage/nft.storage/issues/534)) ([c60cf6c](https://www.github.com/nftstorage/nft.storage/commit/c60cf6c06dc5812f980152fcb9b451a84cf9aba7))
+* prettier and LF line endings (no functional changes) ([#580](https://www.github.com/nftstorage/nft.storage/issues/580)) ([e1e5bc4](https://www.github.com/nftstorage/nft.storage/commit/e1e5bc47e5ae112a0775a25b275691a818665f37))
 
-## [1.7.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.6.1...website-v1.7.0) (2021-10-08)
+## [1.7.0](https://www.github.com/nftstorage/nft.storage/compare/website-v1.6.1...website-v1.7.0) (2021-10-08)
 
 
 ### Features
 
-* add full created date tooltip ([7f9bc57](https://www.github.com/ipfs-shipyard/nft.storage/commit/7f9bc579cfc691804f848d2691b988ebb8e9f3c2))
-* add maintenance banner ([#544](https://www.github.com/ipfs-shipyard/nft.storage/issues/544)) ([604c3c0](https://www.github.com/ipfs-shipyard/nft.storage/commit/604c3c0f0f1e1edf300f3faf00d72434eaeb23fd)), closes [#487](https://www.github.com/ipfs-shipyard/nft.storage/issues/487) [#537](https://www.github.com/ipfs-shipyard/nft.storage/issues/537)
-* add more info to the homepage ([#489](https://www.github.com/ipfs-shipyard/nft.storage/issues/489)) ([0ba05be](https://www.github.com/ipfs-shipyard/nft.storage/commit/0ba05bea5fae47cd41c34949f4f4cddd38247925)), closes [#424](https://www.github.com/ipfs-shipyard/nft.storage/issues/424)
-* add more questions to the FAQ ([#438](https://www.github.com/ipfs-shipyard/nft.storage/issues/438)) ([02ae154](https://www.github.com/ipfs-shipyard/nft.storage/commit/02ae154c4cf708f1f7c5ec51c1b4dfa3af59d236))
-* add navbar and fix mobile navigation ([#401](https://www.github.com/ipfs-shipyard/nft.storage/issues/401)) ([6049965](https://www.github.com/ipfs-shipyard/nft.storage/commit/60499653c4ebb4ad4590527243a09bc8bb73c540))
-* content update on homepage about section to link to nft school ([#526](https://www.github.com/ipfs-shipyard/nft.storage/issues/526)) ([32e0c71](https://www.github.com/ipfs-shipyard/nft.storage/commit/32e0c7198c75f058a944bba84f86a6b9773bff11))
-* handle errors in the files page ([#433](https://www.github.com/ipfs-shipyard/nft.storage/issues/433)) ([182d484](https://www.github.com/ipfs-shipyard/nft.storage/commit/182d484f10d21c34248a5e7436f355fc6cce28cd))
-* migrate database to postgres  ([#263](https://www.github.com/ipfs-shipyard/nft.storage/issues/263)) ([ff0c919](https://www.github.com/ipfs-shipyard/nft.storage/commit/ff0c919ad63f8452357ff5f23b3f1ecd24880c86))
+* add full created date tooltip ([7f9bc57](https://www.github.com/nftstorage/nft.storage/commit/7f9bc579cfc691804f848d2691b988ebb8e9f3c2))
+* add maintenance banner ([#544](https://www.github.com/nftstorage/nft.storage/issues/544)) ([604c3c0](https://www.github.com/nftstorage/nft.storage/commit/604c3c0f0f1e1edf300f3faf00d72434eaeb23fd)), closes [#487](https://www.github.com/nftstorage/nft.storage/issues/487) [#537](https://www.github.com/nftstorage/nft.storage/issues/537)
+* add more info to the homepage ([#489](https://www.github.com/nftstorage/nft.storage/issues/489)) ([0ba05be](https://www.github.com/nftstorage/nft.storage/commit/0ba05bea5fae47cd41c34949f4f4cddd38247925)), closes [#424](https://www.github.com/nftstorage/nft.storage/issues/424)
+* add more questions to the FAQ ([#438](https://www.github.com/nftstorage/nft.storage/issues/438)) ([02ae154](https://www.github.com/nftstorage/nft.storage/commit/02ae154c4cf708f1f7c5ec51c1b4dfa3af59d236))
+* add navbar and fix mobile navigation ([#401](https://www.github.com/nftstorage/nft.storage/issues/401)) ([6049965](https://www.github.com/nftstorage/nft.storage/commit/60499653c4ebb4ad4590527243a09bc8bb73c540))
+* content update on homepage about section to link to nft school ([#526](https://www.github.com/nftstorage/nft.storage/issues/526)) ([32e0c71](https://www.github.com/nftstorage/nft.storage/commit/32e0c7198c75f058a944bba84f86a6b9773bff11))
+* handle errors in the files page ([#433](https://www.github.com/nftstorage/nft.storage/issues/433)) ([182d484](https://www.github.com/nftstorage/nft.storage/commit/182d484f10d21c34248a5e7436f355fc6cce28cd))
+* migrate database to postgres  ([#263](https://www.github.com/nftstorage/nft.storage/issues/263)) ([ff0c919](https://www.github.com/nftstorage/nft.storage/commit/ff0c919ad63f8452357ff5f23b3f1ecd24880c86))
 
 
 ### Bug Fixes
 
-* files pagination ([c6bb930](https://www.github.com/ipfs-shipyard/nft.storage/commit/c6bb93001d762825ff14225e9afc8c368f90db89))
-* retain correct value for NFT type ([#548](https://www.github.com/ipfs-shipyard/nft.storage/issues/548)) ([ad597d0](https://www.github.com/ipfs-shipyard/nft.storage/commit/ad597d0eae302e1ea09f97d4b563840ab82c5986))
-* v1 callback login redirect ([#479](https://www.github.com/ipfs-shipyard/nft.storage/issues/479)) ([ebc6917](https://www.github.com/ipfs-shipyard/nft.storage/commit/ebc6917cd2980613dcadf8c81bd180e8f4d76b0a))
+* files pagination ([c6bb930](https://www.github.com/nftstorage/nft.storage/commit/c6bb93001d762825ff14225e9afc8c368f90db89))
+* retain correct value for NFT type ([#548](https://www.github.com/nftstorage/nft.storage/issues/548)) ([ad597d0](https://www.github.com/nftstorage/nft.storage/commit/ad597d0eae302e1ea09f97d4b563840ab82c5986))
+* v1 callback login redirect ([#479](https://www.github.com/nftstorage/nft.storage/issues/479)) ([ebc6917](https://www.github.com/nftstorage/nft.storage/commit/ebc6917cd2980613dcadf8c81bd180e8f4d76b0a))
 
 
 ### Changes
 
-* rename account table to user ([#485](https://www.github.com/ipfs-shipyard/nft.storage/issues/485)) ([a3423a1](https://www.github.com/ipfs-shipyard/nft.storage/commit/a3423a18b537d7b1accdf2ffa4d716939a7bdd2a))
-* setup countly analytics ([#432](https://www.github.com/ipfs-shipyard/nft.storage/issues/432)) ([8b90bfa](https://www.github.com/ipfs-shipyard/nft.storage/commit/8b90bfa4ba5b2a51c9f10b169e15fa217948faed))
-* **website:** update nft.storage client dep ([bd6c37d](https://www.github.com/ipfs-shipyard/nft.storage/commit/bd6c37d815b2b9413b87eca2f801fd10d7fbc43c))
+* rename account table to user ([#485](https://www.github.com/nftstorage/nft.storage/issues/485)) ([a3423a1](https://www.github.com/nftstorage/nft.storage/commit/a3423a18b537d7b1accdf2ffa4d716939a7bdd2a))
+* setup countly analytics ([#432](https://www.github.com/nftstorage/nft.storage/issues/432)) ([8b90bfa](https://www.github.com/nftstorage/nft.storage/commit/8b90bfa4ba5b2a51c9f10b169e15fa217948faed))
+* **website:** update nft.storage client dep ([bd6c37d](https://www.github.com/nftstorage/nft.storage/commit/bd6c37d815b2b9413b87eca2f801fd10d7fbc43c))
 
-### [1.6.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.6.0...website-v1.6.1) (2021-09-13)
+### [1.6.1](https://www.github.com/nftstorage/nft.storage/compare/website-v1.6.0...website-v1.6.1) (2021-09-13)
 
 
 ### Bug Fixes
 
-* remove id from getting started CTA link ([#421](https://www.github.com/ipfs-shipyard/nft.storage/issues/421)) ([84e8e12](https://www.github.com/ipfs-shipyard/nft.storage/commit/84e8e12f1a90c04880c3227ac07e600294113566))
-* update homepage illustration ([#410](https://www.github.com/ipfs-shipyard/nft.storage/issues/410)) ([0dcb3cd](https://www.github.com/ipfs-shipyard/nft.storage/commit/0dcb3cd2c057b67179a8a1a0bad2a4531c8d451c))
+* remove id from getting started CTA link ([#421](https://www.github.com/nftstorage/nft.storage/issues/421)) ([84e8e12](https://www.github.com/nftstorage/nft.storage/commit/84e8e12f1a90c04880c3227ac07e600294113566))
+* update homepage illustration ([#410](https://www.github.com/nftstorage/nft.storage/issues/410)) ([0dcb3cd](https://www.github.com/nftstorage/nft.storage/commit/0dcb3cd2c057b67179a8a1a0bad2a4531c8d451c))
 
-## [1.6.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.5.2...website-v1.6.0) (2021-09-09)
+## [1.6.0](https://www.github.com/nftstorage/nft.storage/compare/website-v1.5.2...website-v1.6.0) (2021-09-09)
 
 
 ### Features
 
-* links to metadata.json depending on type ([#398](https://www.github.com/ipfs-shipyard/nft.storage/issues/398)) ([343b835](https://www.github.com/ipfs-shipyard/nft.storage/commit/343b835dc902454b91e702e2845e9f0ec6cae471))
-* remove pinning service from the homepage ([#397](https://www.github.com/ipfs-shipyard/nft.storage/issues/397)) ([aec4669](https://www.github.com/ipfs-shipyard/nft.storage/commit/aec466928ee2ec446ccf0d7f0bcff3764d8c3259))
+* links to metadata.json depending on type ([#398](https://www.github.com/nftstorage/nft.storage/issues/398)) ([343b835](https://www.github.com/nftstorage/nft.storage/commit/343b835dc902454b91e702e2845e9f0ec6cae471))
+* remove pinning service from the homepage ([#397](https://www.github.com/nftstorage/nft.storage/issues/397)) ([aec4669](https://www.github.com/nftstorage/nft.storage/commit/aec466928ee2ec446ccf0d7f0bcff3764d8c3259))
 
 
 ### Bug Fixes
 
-* remove remaining beta information ([#406](https://www.github.com/ipfs-shipyard/nft.storage/issues/406)) ([414f93e](https://www.github.com/ipfs-shipyard/nft.storage/commit/414f93e66b7aa0e67cbd003f39b4b53046112321))
+* remove remaining beta information ([#406](https://www.github.com/nftstorage/nft.storage/issues/406)) ([414f93e](https://www.github.com/nftstorage/nft.storage/commit/414f93e66b7aa0e67cbd003f39b4b53046112321))
 
-### [1.5.2](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.5.1...website-v1.5.2) (2021-08-30)
-
-
-### Bug Fixes
-
-* **website:** fix api docs error ([#352](https://www.github.com/ipfs-shipyard/nft.storage/issues/352)) ([073d5aa](https://www.github.com/ipfs-shipyard/nft.storage/commit/073d5aa29b62de9253e1d362eaf1347b69929fa8)), closes [#348](https://www.github.com/ipfs-shipyard/nft.storage/issues/348)
-
-### [1.5.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.5.0...website-v1.5.1) (2021-08-30)
+### [1.5.2](https://www.github.com/nftstorage/nft.storage/compare/website-v1.5.1...website-v1.5.2) (2021-08-30)
 
 
 ### Bug Fixes
 
-* pin ipfs-car verion to avoid empty upload issue ([d1d56b3](https://www.github.com/ipfs-shipyard/nft.storage/commit/d1d56b346f6480bebfcc3d54ad70bbd14dd4934a))
+* **website:** fix api docs error ([#352](https://www.github.com/nftstorage/nft.storage/issues/352)) ([073d5aa](https://www.github.com/nftstorage/nft.storage/commit/073d5aa29b62de9253e1d362eaf1347b69929fa8)), closes [#348](https://www.github.com/nftstorage/nft.storage/issues/348)
 
-## [1.5.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.4.0...website-v1.5.0) (2021-08-27)
+### [1.5.1](https://www.github.com/nftstorage/nft.storage/compare/website-v1.5.0...website-v1.5.1) (2021-08-30)
+
+
+### Bug Fixes
+
+* pin ipfs-car verion to avoid empty upload issue ([d1d56b3](https://www.github.com/nftstorage/nft.storage/commit/d1d56b346f6480bebfcc3d54ad70bbd14dd4934a))
+
+## [1.5.0](https://www.github.com/nftstorage/nft.storage/compare/website-v1.4.0...website-v1.5.0) (2021-08-27)
 
 
 ### Features
 
-* remove custom multipart parser ([#336](https://www.github.com/ipfs-shipyard/nft.storage/issues/336)) ([029e71a](https://www.github.com/ipfs-shipyard/nft.storage/commit/029e71aefc1b152a080ffb5739e4f7c2565a1e57))
+* remove custom multipart parser ([#336](https://www.github.com/nftstorage/nft.storage/issues/336)) ([029e71a](https://www.github.com/nftstorage/nft.storage/commit/029e71aefc1b152a080ffb5739e4f7c2565a1e57))
 
 
 ### Bug Fixes
 
-* Relaxes image/* requirement ([#334](https://www.github.com/ipfs-shipyard/nft.storage/issues/334)) ([f484297](https://www.github.com/ipfs-shipyard/nft.storage/commit/f484297123de4b5eca900831069dcd3fab2ac3b9))
+* Relaxes image/* requirement ([#334](https://www.github.com/nftstorage/nft.storage/issues/334)) ([f484297](https://www.github.com/nftstorage/nft.storage/commit/f484297123de4b5eca900831069dcd3fab2ac3b9))
 
-## [1.4.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.3.1...website-v1.4.0) (2021-08-11)
+## [1.4.0](https://www.github.com/nftstorage/nft.storage/compare/website-v1.3.1...website-v1.4.0) (2021-08-11)
 
 
 ### Features
 
-* improvements to the setup ([#246](https://www.github.com/ipfs-shipyard/nft.storage/issues/246)) ([6a2501f](https://www.github.com/ipfs-shipyard/nft.storage/commit/6a2501f5c340af87c1571886961920280afec249))
+* improvements to the setup ([#246](https://www.github.com/nftstorage/nft.storage/issues/246)) ([6a2501f](https://www.github.com/nftstorage/nft.storage/commit/6a2501f5c340af87c1571886961920280afec249))
 
 
 ### Bug Fixes
 
-* cf page build error ([#274](https://www.github.com/ipfs-shipyard/nft.storage/issues/274)) ([68ee8ca](https://www.github.com/ipfs-shipyard/nft.storage/commit/68ee8ca0adf217a7ba5a0ea2db1ca0019c344569))
-* **website:** update client docs url ([d8152da](https://www.github.com/ipfs-shipyard/nft.storage/commit/d8152daaa4de94064689e8b93160e6c118316e47))
+* cf page build error ([#274](https://www.github.com/nftstorage/nft.storage/issues/274)) ([68ee8ca](https://www.github.com/nftstorage/nft.storage/commit/68ee8ca0adf217a7ba5a0ea2db1ca0019c344569))
+* **website:** update client docs url ([d8152da](https://www.github.com/nftstorage/nft.storage/commit/d8152daaa4de94064689e8b93160e6c118316e47))
 
-### [1.3.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.3.0...website-v1.3.1) (2021-06-24)
+### [1.3.1](https://www.github.com/nftstorage/nft.storage/compare/website-v1.3.0...website-v1.3.1) (2021-06-24)
 
 
 ### Bug Fixes
 
-* progress percentage ([4717e3c](https://www.github.com/ipfs-shipyard/nft.storage/commit/4717e3c52f438a5aa1e93677a2d05d2b5d2f82a1))
-* remove 100mb limit from uploader ([#208](https://www.github.com/ipfs-shipyard/nft.storage/issues/208)) ([e8b5a90](https://www.github.com/ipfs-shipyard/nft.storage/commit/e8b5a90ccca14ad30a229afaee1d6b40fff5ecdf))
+* progress percentage ([4717e3c](https://www.github.com/nftstorage/nft.storage/commit/4717e3c52f438a5aa1e93677a2d05d2b5d2f82a1))
+* remove 100mb limit from uploader ([#208](https://www.github.com/nftstorage/nft.storage/issues/208)) ([e8b5a90](https://www.github.com/nftstorage/nft.storage/commit/e8b5a90ccca14ad30a229afaee1d6b40fff5ecdf))
 
-## [1.3.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.2.1...website-v1.3.0) (2021-06-23)
+## [1.3.0](https://www.github.com/nftstorage/nft.storage/compare/website-v1.2.1...website-v1.3.0) (2021-06-23)
 
 
 ### Features
 
-* add link to NFT School in FAQ ([#209](https://www.github.com/ipfs-shipyard/nft.storage/issues/209)) ([30d2bc6](https://www.github.com/ipfs-shipyard/nft.storage/commit/30d2bc667df23faf0ebb631568f58b197ec65c1c))
+* add link to NFT School in FAQ ([#209](https://www.github.com/nftstorage/nft.storage/issues/209)) ([30d2bc6](https://www.github.com/nftstorage/nft.storage/commit/30d2bc667df23faf0ebb631568f58b197ec65c1c))
 
-### [1.2.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.2.0...website-v1.2.1) (2021-06-18)
+### [1.2.1](https://www.github.com/nftstorage/nft.storage/compare/website-v1.2.0...website-v1.2.1) (2021-06-18)
 
 
 ### Bug Fixes
 
-* misc docs issues ([#190](https://www.github.com/ipfs-shipyard/nft.storage/issues/190)) ([04e9840](https://www.github.com/ipfs-shipyard/nft.storage/commit/04e9840e35903a6738b0e947c150047ce521f912))
+* misc docs issues ([#190](https://www.github.com/nftstorage/nft.storage/issues/190)) ([04e9840](https://www.github.com/nftstorage/nft.storage/commit/04e9840e35903a6738b0e947c150047ce521f912))
 
-## [1.2.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.1.0...website-v1.2.0) (2021-06-17)
+## [1.2.0](https://www.github.com/nftstorage/nft.storage/compare/website-v1.1.0...website-v1.2.0) (2021-06-17)
 
 
 ### Features
 
-* support CAR file uploads ([#178](https://www.github.com/ipfs-shipyard/nft.storage/issues/178)) ([c7e5130](https://www.github.com/ipfs-shipyard/nft.storage/commit/c7e5130022ac1d0db13269582bdfa5e60d41bdea))
+* support CAR file uploads ([#178](https://www.github.com/nftstorage/nft.storage/issues/178)) ([c7e5130](https://www.github.com/nftstorage/nft.storage/commit/c7e5130022ac1d0db13269582bdfa5e60d41bdea))
 
-## [1.1.0](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.0.3...website-v1.1.0) (2021-05-26)
+## [1.1.0](https://www.github.com/nftstorage/nft.storage/compare/website-v1.0.3...website-v1.1.0) (2021-05-26)
 
 
 ### Features
 
-* add API key copy button ([#147](https://www.github.com/ipfs-shipyard/nft.storage/issues/147)) ([db23839](https://www.github.com/ipfs-shipyard/nft.storage/commit/db238391f94b22f8b1978651bd397629919aa033))
+* add API key copy button ([#147](https://www.github.com/nftstorage/nft.storage/issues/147)) ([db23839](https://www.github.com/nftstorage/nft.storage/commit/db238391f94b22f8b1978651bd397629919aa033))
 
-### [1.0.3](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.0.2...website-v1.0.3) (2021-05-14)
+### [1.0.3](https://www.github.com/nftstorage/nft.storage/compare/website-v1.0.2...website-v1.0.3) (2021-05-14)
 
-
-### Bug Fixes
-
-* **website:** try another auto release ([3e7e997](https://www.github.com/ipfs-shipyard/nft.storage/commit/3e7e9971e05766f0a55c6423a1f74e20601be49c))
-
-### [1.0.2](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.0.1...website-v1.0.2) (2021-05-14)
 
 ### Bug Fixes
 
-- **website:** release website ([78134c1](https://www.github.com/ipfs-shipyard/nft.storage/commit/78134c17d82c93f007f76f2d7b3535c155424883))
+* **website:** try another auto release ([3e7e997](https://www.github.com/nftstorage/nft.storage/commit/3e7e9971e05766f0a55c6423a1f74e20601be49c))
 
-### [1.0.1](https://www.github.com/ipfs-shipyard/nft.storage/compare/website-v1.0.0...website-v1.0.1) (2021-05-14)
+### [1.0.2](https://www.github.com/nftstorage/nft.storage/compare/website-v1.0.1...website-v1.0.2) (2021-05-14)
 
 ### Bug Fixes
 
-- **website:** add description ([6e302e5](https://www.github.com/ipfs-shipyard/nft.storage/commit/6e302e55223a3d8d64e3bf15a782ac09feb5c8f4))
-- **website:** fix version ([514ab99](https://www.github.com/ipfs-shipyard/nft.storage/commit/514ab99a1545266110afeb15b9f52b817ada5ac9))
+- **website:** release website ([78134c1](https://www.github.com/nftstorage/nft.storage/commit/78134c17d82c93f007f76f2d7b3535c155424883))
+
+### [1.0.1](https://www.github.com/nftstorage/nft.storage/compare/website-v1.0.0...website-v1.0.1) (2021-05-14)
+
+### Bug Fixes
+
+- **website:** add description ([6e302e5](https://www.github.com/nftstorage/nft.storage/commit/6e302e55223a3d8d64e3bf15a782ac09feb5c8f4))
+- **website:** fix version ([514ab99](https://www.github.com/nftstorage/nft.storage/commit/514ab99a1545266110afeb15b9f52b817ada5ac9))
 
 ## 1.0.0 (2021-05-14)
 
@@ -178,4 +178,4 @@
 
 ### Features
 
-- **website:** new website ci ([a79d621](https://www.github.com/ipfs-shipyard/nft.storage/commit/a79d6218ecb6394ac10a60ae5b4c3959e63ed41f))
+- **website:** new website ci ([a79d621](https://www.github.com/nftstorage/nft.storage/commit/a79d6218ecb6394ac10a60ae5b4c3959e63ed41f))

--- a/packages/website/components/footer.js
+++ b/packages/website/components/footer.js
@@ -52,7 +52,7 @@ export default function Footer() {
         <span className="db db-m dib-ns mv3">
           Need Help?{' '}
           <a
-            href="https://github.com/ipfs-shipyard/nft.storage/issues/new"
+            href="https://github.com/nftstorage/nft.storage/issues/new"
             className="nspink underline-hover no-underline"
             onClick={onLinkClick}
           >

--- a/packages/website/pages/index.js
+++ b/packages/website/pages/index.js
@@ -113,7 +113,7 @@ function About() {
         </a>
         , or by using{' '}
         <a
-          href="https://github.com/ipfs-shipyard/ipfs-desktop"
+          href="https://github.com/nftstorage/ipfs-desktop"
           className="black"
           target="_blank"
           rel="noopener noreferrer"
@@ -347,7 +347,7 @@ console.log(metadata.url)
             <p className="lh-copy">
               View the{' '}
               <a
-                href="https://ipfs-shipyard.github.io/nft.storage/client/"
+                href="https://nftstorage.github.io/nft.storage/client/"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="black"
@@ -360,7 +360,7 @@ console.log(metadata.url)
               For additional example code, check out our{' '}
               <a
                 className="black"
-                href="https://github.com/ipfs-shipyard/nft.storage/tree/2bb82aeb23ac139513c1af6615d010579f22a7cc/packages/client/examples/node.js"
+                href="https://github.com/nftstorage/nft.storage/tree/2bb82aeb23ac139513c1af6615d010579f22a7cc/packages/client/examples/node.js"
                 target="_blank"
                 rel="noreferrer"
               >
@@ -435,7 +435,7 @@ console.log(metadata.url)
               For additional example code, check out our{' '}
               <a
                 className="black"
-                href="https://github.com/ipfs-shipyard/nft.storage/tree/2bb82aeb23ac139513c1af6615d010579f22a7cc/packages/client/examples/browser"
+                href="https://github.com/nftstorage/nft.storage/tree/2bb82aeb23ac139513c1af6615d010579f22a7cc/packages/client/examples/browser"
                 target="_blank"
                 rel="noreferrer"
               >


### PR DESCRIPTION
Updates the links to this repo from `ipfs-shipyard` to `nftstorage`. Wow that's a lot of references.