### PR TITLE
fix: specify node engine in root (16.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "graphql": "^15.5.1",
     "prettier": "2.4.0",
     "esbuild": "0.12.21"
+  },
+  "engines": {
+    "node": "16.x"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -572,11 +572,6 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.2.tgz#e15824405df137129918205e43cb5e9339589745"
   integrity sha512-e/pIKVdB+tGQYa1cW3sAeHm8gzEri/HYLZHT4WZojrUxgWXqx8pk7S7Xs47uBcFTqBDRvK3EcQpPLf3XdVsDdg==
 
-"@nftstorage/ipfs-cluster@^3.4.2":
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/@nftstorage/ipfs-cluster/-/ipfs-cluster-3.4.2.tgz#b1a36659c66a7acb992eb4ea1032459a8b8ec353"
-  integrity sha512-SH7Z9lzyRr5bUlwCk46ltpGg8nP7kwRqbBakuUkQc1bttcjSlsDUrFCa11LNzeriKJBfE38V0Yxojv/hhRRdNw==
-
 "@nftstorage/ipfs-cluster@^3.4.3":
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/@nftstorage/ipfs-cluster/-/ipfs-cluster-3.4.3.tgz#d29566d062cab187e26694ff337d105e8c2d3228"


### PR DESCRIPTION
Heroku is not detecting the engine in the packages, without some more complicated buildpack. This puts node 16.x in the root - this should be nonbreaking, and will make niftysave resume progress