### PR TITLE
chore: add /store endpoint to API schema

### DIFF
--- a/packages/website/public/schema.yml
+++ b/packages/website/public/schema.yml
@@ -9,6 +9,64 @@ servers:
 tags:
   - name: NFT Storage
 paths:
+  /store:
+    post:
+      tags:
+        - NFT Storage
+      summary: Store an ERC-1155 compatible NFT
+      description: |
+        Store an [ERC-1155](https://eips.ethereum.org/EIPS/eip-1155)-compatible NFT as 
+        a collection of content-addressed objects connected by IPFS CID links.
+
+        The POST request accepts `multipart/form-data` content, which must contain a form field named `meta`.
+
+        The `meta` field must contain a JSON string that conforms to the [ERC-1155 metadata schema](https://eips.ethereum.org/EIPS/eip-1155#metadata).
+
+        Any field inside the `meta` object whose value is set to `null` will be treated as a file reference, 
+        and you must supply a form data field containing the file content as a binary string.
+
+        The name of the form data field containing the file content should be the "path" of the JSON field, using `.` to traverse nested
+        objects.
+
+        For example, with a `meta` object of the form:
+
+          ```json
+          {
+            "name": "Hello",
+            "image": null,
+            "properties": {
+              "videoClip": null
+            }
+          }
+          ```
+
+        You must include form fields named `image` and `properties.videoClip` in your request body, with the content of the image and video files as the form field values.
+
+        All form fields other than `meta` must contain binary file data, and the field name must match a key in the `meta` JSON object whose value is `null`.
+
+        ### Mime Type Recommendations
+
+        The ERC-1155 metadata standard specifies that the `image` metadata field should reference a file with a content type of `image/*`.
+        An earlier version of this API enforced this as a requirement, but this proved to be incompatible with some existing systems and the
+        requirement was relaxed, although you may see a warning when using the official JavaScript client.
+
+        We highly recommend that you only use content with an `image/*` content type for your `image` field, and include other content types in the
+        `properties` field as additional references.
+
+      operationId: store
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                meta:
+                  type: string
+              additionalProperties:
+                type: string
+                format: binary
+
   /upload:
     post:
       tags:
@@ -24,7 +82,8 @@ paths:
 
         You can also upload a Content Addressed Archive (CAR) file, by setting the request body as a single CAR Blob/File object and providing the request header `Content-Type: application/car`
         Providing a CAR file allows you to pre-compute the root CID for 1 or more files, ensures that the nft.storage will store and provide your assets with the same CID.
-      operationId: store
+
+      operationId: upload
       requestBody:
         required: true
         content:
@@ -192,7 +251,7 @@ components:
         type:
           type: string
           example: image/jpeg
-          description: MIME type of the upload file or 'directory' when uploading multiple files.
+          description: MIME type of the uploaded file or 'directory' when uploading multiple files.
         scope:
           description: Name of the JWT token used to create this NFT.
           type: string

--- a/packages/website/public/schema.yml
+++ b/packages/website/public/schema.yml
@@ -22,8 +22,7 @@ paths:
 
         The `meta` field must contain a JSON string that conforms to the [ERC-1155 metadata schema](https://eips.ethereum.org/EIPS/eip-1155#metadata).
 
-        Any field inside the `meta` object whose value is set to `null` will be treated as a file reference, 
-        and you must supply a form data field containing the file content as a binary string.
+        Any field(s) inside the `meta` object can be substituted with an ipfs URL to a file(s), by providing a form data field with a name matching a (`.` delimited) property path and value containing the file content (in binary string or plain text depending on file format).
 
         The name of the form data field containing the file content should be the "path" of the JSON field, using `.` to traverse nested
         objects.
@@ -33,16 +32,16 @@ paths:
           ```json
           {
             "name": "Hello",
-            "image": null,
+            "image": undefined,
             "properties": {
-              "videoClip": null
+              "videoClip": undefined
             }
           }
           ```
 
         You must include form fields named `image` and `properties.videoClip` in your request body, with the content of the image and video files as the form field values.
 
-        All form fields other than `meta` must contain binary file data, and the field name must match a key in the `meta` JSON object whose value is `null`.
+        All form fields other than `meta` must contain binary file data, and the field name will be used as a '.' delimited property path for the `meta` object, as described above. If the form field name matches a `meta` property with a non-falsy value, the request will be rejected with an error.
 
         ### Mime Type Recommendations
 


### PR DESCRIPTION
I started to add a note about content types to the API docs, but it seems that the `/store` endpoint wasn't in the schema, just `/upload`. 

So this adds docs for the `/store` endpoint based on what I could glean from the code. Someone should probably look it over to make sure it's correct.

May need some formatting tweaks and so on - I wasn't able to run the website build locally, since my env isn't set up, so I haven't seen it rendered yet.

Also closes #490 - we actually allow all file types now, but I added a recommendation to only use images for the `image` field.