### PR TITLE
feat: add doc comments & include interface.ts in typedoc

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -35,7 +35,7 @@
     "build:ts": "tsc --build",
     "build:cjs": "rollup --config rollup.config.js",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && npx codecov",
-    "typedoc": "typedoc src/lib.js  --out ../../docs/client",
+    "typedoc": "typedoc",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -39,6 +39,7 @@ const MAX_CHUNK_SIZE = 1024 * 1024 * 10 // chunk to ~10MB CARs
 
 /**
  * @implements API.InstanceAPI
+ * @implements API.Service
  *
  * The NFTStorage class provides a client interface for the
  * [NFT.Storage HTTP API](https://nft.storage/api-docs/).

--- a/packages/client/src/platform.ts
+++ b/packages/client/src/platform.ts
@@ -1,8 +1,55 @@
-export const fetch = globalThis.fetch
+/**
+ * See https://developer.mozilla.org/en-US/docs/Web/API/FormData
+ *
+ * Node.js implementation: https://www.npmjs.com/package/@web-std/form-data
+ */
 export const FormData = globalThis.FormData
+
+/**
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Fetch
+ *
+ * Node.js implementation: https://www.npmjs.com/package/@web-std/fetch
+ */
+export const fetch = globalThis.fetch
+
+/**
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Headers
+ *
+ * Node.js implementation: https://www.npmjs.com/package/@web-std/fetch
+ */
 export const Headers = globalThis.Headers
+
+/**
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Request
+ *
+ * Node.js implementation: https://www.npmjs.com/package/@web-std/fetch
+ */
 export const Request = globalThis.Request
+
+/**
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Response
+ *
+ * Node.js implementation: https://www.npmjs.com/package/@web-std/fetch
+ */
 export const Response = globalThis.Response
+
+/**
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Blob
+ *
+ * Node.js implementation: https://www.npmjs.com/package/@web-std/file
+ */
 export const Blob = globalThis.Blob
+
+/**
+ * See https://developer.mozilla.org/en-US/docs/Web/API/File
+ *
+ * Node.js implementation: https://www.npmjs.com/package/@web-std/file
+ */
 export const File = globalThis.File
+
+/**
+ * See https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
+ *
+ * Node.js implementation: https://www.npmjs.com/package/@web-std/blob
+ */
 export const ReadableStream = globalThis.ReadableStream

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -64,5 +64,9 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": ["src", "test"]
+  "include": ["src", "test"],
+  "typedocOptions": {
+    "entryPoints": ["./src/lib.js", "./src/lib/interface.ts"],
+    "out": "../../docs/client"
+  }
 }


### PR DESCRIPTION
I had a go at improving the typedoc output a bit. Now it includes the type definitions from `src/lib/interface.ts`, so you can click through to things like the API interface.

Speaking of which, the `@implements` tag on the `NFTStorage` class was `API.Service`, but it should be `API.API`, since `API.Service` is the `{ token, endpoint }` context object. When I switched it to `@implements API.API`, I got a bunch of type errors since it got confused by the static methods having the same name as the instance methods.

So this changes the `API.API` interface definition and splits it into two: `InstanceAPI` has the instance methods of the `NFTStorage` class while `StaticAPI` has the static methods. Now you can do `@implements API.InstanceAPI` in the jsdoc and tsc is happy.

