### PR TITLE
fix: list API maximum limit value

### DIFF
--- a/packages/website/public/schema.yml
+++ b/packages/website/public/schema.yml
@@ -482,7 +482,7 @@ components:
         type: integer
         format: int32
         minimum: 1
-        maximum: 100
+        maximum: 1000
         default: 10
 security:
   - bearerAuth: []


### PR DESCRIPTION
The limit was recently upped to 1,000 from 100 as we now use a database that can handle this load. The change was not reflected in the OpenAPI docs.

refs https://github.com/nftstorage/nft.storage/issues/754