### PR TITLE
feat: add docker-compose and devcontainer.json for local dev env

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:16
+
+# install psql client for poking at the db
+RUN apt-get update && apt-get install -y postgresql-client
+
+ENV DEV_USERNAME=
+
+COPY .devcontainer/post-attach.sh /bin/
+
+RUN mkdir /workspace && chown node /workspace
+WORKDIR /workspace
+USER node
+
+# install wrangler cli globally
+RUN npm install -g @cloudflare/wrangler
+
+# prevent container from immediately exiting when run
+CMD sleep infinity 

--- a/.devcontainer/compose.sh
+++ b/.devcontainer/compose.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# make sure we're running from the .devcontainer dir, even if invoked from elsewhere
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+
+docker-compose -f docker-compose.yml -f docker-compose.db.yml -f docker-compose.extend.yml "$@"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "dockerComposeFile": ["./docker-compose.yml", "./docker-compose.db.yml", "./docker-compose.extend.yml" ],
+  "service": "dev",
+  "workspaceFolder": "/workspace",
+  "forwardPorts": [3000, 5432, 9094, 9095, 8787],
+  "remoteUser": "node",
+  "shutdownAction": "stopCompose",
+  "postAttachCommand": "/bin/post-attach.sh",
+}

--- a/.devcontainer/docker-compose.db.yml
+++ b/.devcontainer/docker-compose.db.yml
@@ -1,0 +1,1 @@
+../packages/api/db/docker/docker-compose.yml

--- a/.devcontainer/docker-compose.extend.yml
+++ b/.devcontainer/docker-compose.extend.yml
@@ -1,0 +1,8 @@
+version: '3.6'
+
+# use this to override any service definitions for your local env
+# don't check changes to this file into git!
+# you can run git update-index --assume-unchanged .devcontainer/docker-compose.extend.yml
+# to prevent changes from being tracked
+
+services: {}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,8 +20,8 @@ services:
       - "..:/workspace"
     environment:
       DEV_USERNAME: "${USER}"
-    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:db
+    ports:
+      - "0.0.0.0:8787:8787"
 
   # IPFS node used by cluster node
   ipfs0:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,87 @@
+# This compose file brings up a local development environment containing
+# instances of all the services that the nft.storage API depends on.
+#
+# Because the API runs in a cloudflare worker, the services it depends on
+# must be exposed to the internet. The various -tunnel services here expose
+# things using [localtunnel](https://github.com/localtunnel/localtunnel)
+# 
+
+
+version: '3.6'
+
+services:
+
+  # a 
+  dev:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - "..:/workspace"
+    environment:
+      DEV_USERNAME: "${USER}"
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+
+  # IPFS node used by cluster node
+  ipfs0:
+    image: ipfs/go-ipfs:latest
+#   ports:
+#     - "4001:4001" # ipfs swarm - expose if needed/wanted
+#     - "5001:5001" # ipfs api - expose if needed/wanted
+#     - "8080:8080" # ipfs gateway - expose if needed/wanted
+    volumes:
+      - ./cluster-data/ipfs0:/data/ipfs
+      
+  # An ipfs-cluster node, with proxy api exposed on port 9095
+  cluster0:
+    image: ipfs/ipfs-cluster:latest
+    depends_on:
+      - ipfs0
+    environment:
+      CLUSTER_PEERNAME: cluster0
+      CLUSTER_SECRET: ${CLUSTER_SECRET} # From shell variable if set
+      CLUSTER_IPFSHTTP_NODEMULTIADDRESS: /dns4/ipfs0/tcp/5001
+      CLUSTER_CRDT_TRUSTEDPEERS: '*' # Trust all peers in Cluster
+      CLUSTER_RESTAPI_HTTPLISTENMULTIADDRESS: /ip4/0.0.0.0/tcp/9094 # Expose API
+      CLUSTER_MONITORPINGINTERVAL: 2s # Speed up peer discovery
+      CLUSTER_IPFSPROXY_NODEMULTIADDRESS: /dns4/ipfs0/tcp/5001
+      CLUSTER_IPFSPROXY_LISTENMULTIADDRESS: /ip4/0.0.0.0/tcp/9095
+    ports:
+          - "0.0.0.0:9094:9094"
+          - "0.0.0.0:9095:9095"
+    volumes:
+      - ./cluster-data/cluster0:/data/ipfs-cluster
+
+### Tunnels
+
+  cluster-api-tunnel:
+    environment:
+      PORT: "9094"
+      LOCAL_HOST: "cluster0"
+      SUBDOMAIN: "${USER}-cluster-api-${DEV_CLUSTER_PROJECT:-nft-storage}"
+    depends_on:
+      - cluster0
+    build:
+      context: ./localtunnel
+
+  ipfs-api-proxy-tunnel:
+    environment:
+      PORT: "9095"
+      LOCAL_HOST: "cluster0"
+      SUBDOMAIN: "${USER}-ipfs-proxy-api-${DEV_CLUSTER_PROJECT:-nft-storage}" 
+    depends_on:
+      - cluster0
+    build:
+      context: ./localtunnel
+
+
+  postgrest-tunnel:
+    environment:
+      PORT: "3000"
+      LOCAL_HOST: "rest"
+      SUBDOMAIN: "${USER}-postgrest-${DEV_CLUSTER_PROJECT:-nft-storage}"
+    depends_on:
+      - rest
+    build:
+      context: ./localtunnel

--- a/.devcontainer/localtunnel/Dockerfile
+++ b/.devcontainer/localtunnel/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:16-alpine
+
+RUN chown -R node /usr/local/
+
+USER node
+
+ENV PORT=8080
+ENV LOCAL_HOST=localhost
+ENV SUBDOMAIN=
+
+RUN npm install -g localtunnel
+
+ENTRYPOINT [ "lt" ]
+

--- a/.devcontainer/post-attach.sh
+++ b/.devcontainer/post-attach.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# This script runs when attaching to the dev container in vscode. 
+
+cd /workspace
+
+yarn install
+
+node packages/tools/cli.js local-env-check

--- a/.devcontainer/postgres
+++ b/.devcontainer/postgres
@@ -1,0 +1,1 @@
+../packages/api/db/docker/postgres

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ yarn-error.log*
 .production.env
 .env
 
+
+.devcontainer/cluster-data
+
 dist
 node_modules
 worker

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,5 +16,6 @@ CHANGELOG.md
 .gitignore
 .editorconfig
 .gitattributes
+.devcontainer
 **/yarn.lock*
 *.toml

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -21,7 +21,8 @@
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^5.1.0"
+    "eslint-plugin-promise": "^5.1.0",
+    "toml": "^3.0.0"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/tools/utils/localenv.js
+++ b/packages/tools/utils/localenv.js
@@ -1,0 +1,256 @@
+import dotenv from 'dotenv'
+import path from 'path'
+import fs from 'fs/promises'
+import childProcess from 'child_process'
+import toml from 'toml'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ENV_PATH = path.join(__dirname, '..', '..', '..', '.env')
+const API_DIR = path.join(__dirname, '..', '..', 'api')
+
+const REQUIRED_VARS = [
+  {
+    name: 'CF_ACCOUNT_ID',
+    desc:
+      'CloudFlare account id. Get from `wrangler whoami` after logging in with `wrangler login`',
+  },
+  {
+    name: 'CF_TOKEN',
+    desc:
+      'CloudFlare API token. Go to https://dash.cloudflare.com/profile/api-tokens and use CF Workers template.',
+  },
+  {
+    name: 'DATABASE_URL',
+    desc: 'URL of postgrest DB api for local development.',
+    defaultValue: `https://${process.env.DEV_USERNAME ||
+      process.env.USER}-postgrest-nft-storage.loca.lt`,
+  },
+  {
+    name: 'DATABASE_CONNECTION',
+    desc: 'Connection URI for local db.',
+    defaultValue: 'postgresql://postgres:postgres@localhost:5432/postgres',
+  },
+  {
+    name: 'DATABASE_TOKEN',
+    desc:
+      "Signed JWT for local db API. Use the default if you're using the devcontainer / docker-compose setup.",
+    defaultValue:
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoicG9zdGdyZXMifQ.oM0SXF31Vs1nfwCaDxjlczE237KcNKhTpKEYxMX-jEU',
+  },
+  {
+    name: 'PINATA_JWT',
+    desc:
+      'Pinata API token. Go to  https://app.pinata.cloud/keys and make a key with all Pinning API permissions.',
+  },
+  {
+    name: 'DAG_CARGO_HOST',
+    desc:
+      'hostname / ip for dag-cargo database (read-only replica). Get from team 1Password if working on PL-managed instance.',
+  },
+  {
+    name: 'DAG_CARGO_DATABASE',
+    desc:
+      'hostname / ip for dag-cargo database (read-only replica). Get from team 1Password if working on PL-managed instance.',
+  },
+  {
+    name: 'DAG_CARGO_USER',
+    desc:
+      'username for dag-cargo database (read-only replica). Get from team 1Password if working on PL-managed instance.',
+  },
+  {
+    name: 'DAG_CARGO_PASSWORD',
+    desc:
+      'password for dag-cargo database (read-only replica). Get from team 1Password if working on PL-managed instance.',
+  },
+]
+
+const REQUIRED_WRANGLER_SECRETS = [
+  {
+    name: 'DATABASE_TOKEN',
+    desc:
+      "Signed JWT for local db API. Use the default if you're using the devcontainer / docker-compose setup.",
+    defaultValue:
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoicG9zdGdyZXMifQ.oM0SXF31Vs1nfwCaDxjlczE237KcNKhTpKEYxMX-jEU',
+  },
+  {
+    name: 'MAGIC_SECRET_KEY',
+    desc:
+      'Secret API key for magic.link. Sign up for an account at https://magic.link and make a new project, then use the secret key.',
+  },
+  {
+    name: 'PINATA_JWT',
+    desc:
+      'Pinata API token. Go to  https://app.pinata.cloud/keys and make a key with all Pinning API permissions.',
+  },
+  {
+    name: 'SALT',
+    desc: 'Random salt. See packages/api/README.md',
+  },
+  {
+    name: 'SENTRY_DSN',
+    desc:
+      'Sentry DSN. Sign up for an account at https://sentry.io, make a new app, and copy the DSN.',
+  },
+]
+
+class LocalEnv {
+  static async lint() {
+    const envOk = await this.lintEnvFile()
+    let wranglerOk = true
+    let loggedIn = await this.checkWranglerIsAuthenticated()
+    if (!loggedIn) {
+      loggedIn = await this.tryWranglerLogin()
+    }
+
+    if (loggedIn) {
+      wranglerOk = await this.checkWranglerToml()
+    } else {
+      console.warn(
+        'cloudflare wrangler not authenticated. skipping validation of wrangler config.'
+      )
+    }
+
+    if (envOk && wranglerOk) {
+      console.log('Everything looks okay!')
+      console.log(
+        'If this is a new dev env, run the following to setup the db:'
+      )
+      console.log('node ./packages/api/scripts/cli.js db-sql --cargo --testing')
+    } else {
+      console.error(
+        'Your config seems to have errors. Please address the issues printed above and try again'
+      )
+    }
+  }
+
+  static async checkWranglerIsAuthenticated() {
+    console.log('verifying that wrangler is authenticated...')
+    try {
+      childProcess.execSync('wrangler whoami')
+      return true
+    } catch (e) {
+      // console.error('error running "wrangler whoami": ', e.stderr.toString())
+      return false
+    }
+  }
+
+  static async tryWranglerLogin() {
+    const env = await this.loadEnvFile()
+    if (!env.CF_TOKEN) {
+      return false
+    }
+    console.log('trying to authenticate wrangler using CF_TOKEN value...')
+    try {
+      childProcess.execSync('wrangler config', { input: env.CF_TOKEN + '\n' })
+    } catch (e) {
+      console.error(`error running 'wrangler config': ${e}`)
+      return false
+    }
+    return true
+  }
+
+  static getDevUsername() {
+    // DEV_USERNAME is set when running in a devcontainer, based on the value of $USER at
+    // the time the dev container was built. If you're running outside the container,
+    // we just use USER instead.
+    const user = process.env.DEV_USERNAME || process.env.USER
+    if (!user) {
+      throw new Error(
+        'Unable to determine username. Set DEV_USERNAME or USER env variables.'
+      )
+    }
+    return user
+  }
+
+  static async checkWranglerToml() {
+    const tomlPath = path.join(API_DIR, 'wrangler.toml')
+    const content = await fs.readFile(tomlPath, { encoding: 'utf-8' })
+    const cfg = toml.parse(content)
+    const user = this.getDevUsername()
+    if (!cfg.env[user]) {
+      console.error(`missing wrangler configuration for your username ${user}`)
+      console.error(
+        `add a section to packages/api/wrangler.toml named [env.${user}]`
+      )
+      console.error('see packages/api/README.md for details')
+      return false
+    }
+
+    return this.checkWranglerSecrets()
+  }
+
+  static checkWranglerSecrets() {
+    console.log('checking that all required wrangler secrets are present...')
+    const cwd = process.cwd()
+    let ok = true
+    try {
+      process.chdir(API_DIR)
+      const user = this.getDevUsername()
+      const s = childProcess.execSync(`wrangler secret list --env ${user}`)
+      const secrets = JSON.parse(s)
+      const secretNames = new Set(secrets.map(s => s.name))
+      for (const { name, desc, defaultValue } of REQUIRED_WRANGLER_SECRETS) {
+        if (secretNames.has(name)) {
+          continue
+        }
+        console.error(`missing wrangler secret ${name}: ${desc}`)
+        console.error(`make sure you're in packages/api, then run:`)
+        console.error(`wrangler secret put ${name} --env ${user}`)
+        if (defaultValue) {
+          console.error('default value for local dev: ' + defaultValue)
+        }
+        ok = false
+      }
+    } finally {
+      process.chdir(cwd)
+    }
+    return ok
+  }
+
+  static async loadEnvFile(envFilePath = ENV_PATH) {
+    const content = await fs.readFile(envFilePath, { encoding: 'utf-8' })
+    return dotenv.parse(content)
+  }
+
+  /**
+   * Checks the .env file in the repo root to see if it looks like it'll work
+   * for local development.
+   *
+   * @returns false if the env has issues, true if everything looks okay
+   */
+  static async lintEnvFile(envFilePath = ENV_PATH) {
+    let env
+    try {
+      env = await this.loadEnvFile(envFilePath)
+    } catch (e) {
+      console.error(`error reading .env file from repo root: ${e}`)
+      return false
+    }
+
+    const errors = []
+    for (const { name, desc, defaultValue } of REQUIRED_VARS) {
+      if (env[name]) {
+        // todo: maybe validate the values? for now just assume they're fine if they exist
+        continue
+      }
+      let msg = `missing required environment variable ${name}: ${desc}`
+      if (defaultValue) {
+        msg += '\ndefault for local dev:'
+        msg += `\n${name}=${defaultValue}`
+      }
+      errors.push(msg)
+    }
+
+    if (errors.length > 0) {
+      console.error(`Your local .env file has some issues:`)
+      for (const e of errors) {
+        console.error(e)
+      }
+      return false
+    }
+    return true
+  }
+}
+
+export default LocalEnv

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,9 +518,9 @@
     "@magic-sdk/types" "^5.2.0"
 
 "@magic-sdk/admin@^1.3.0":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@magic-sdk/admin/-/admin-1.3.1.tgz#7cad0d9a1f9db8224cbcbc5a77526941d2b1a83f"
-  integrity sha512-g1B8MHSBpJoDfFL/y7gd1YtgrwYbS7m7iRijOgiXrkMnIoid0bHgUsRS9LQKy6mImH/JleJSZcaofm2mIvs6tQ==
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@magic-sdk/admin/-/admin-1.3.2.tgz#ad66b691ca97a3693b278ef17aace37bd0fa392a"
+  integrity sha512-fHHzui+3ra3vr1uOYlBZPyANMBobXK22RatAQkCSXzs2Add3Wqga71f/l3ooVr1H1xjGizzBfnDkHahKDqcmPQ==
   dependencies:
     eth-sig-util "2.1.2"
     ethereumjs-util "^6.2.0"
@@ -1078,9 +1078,9 @@
     "@types/node" "*"
 
 "@types/lodash@^4.14.149":
-  version "4.14.176"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.176.tgz#641150fc1cda36fbfa329de603bbb175d7ee20c0"
-  integrity sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ==
+  version "4.14.177"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.177.tgz#f70c0d19c30fab101cad46b52be60363c43c4578"
+  integrity sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw==
 
 "@types/long@^4.0.1":
   version "4.0.1"
@@ -1476,9 +1476,9 @@ ajv@^6.10.0, ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.7.1.tgz#52be6f1736b076074798124293618f132ad07a7e"
-  integrity sha512-gPpOObTO1QjbnN1sVMjJcp1TF9nggMfO4MBR5uQl6ZVTOaEPq5i4oq/6R9q2alMMPB3eg53wFv1RuJBLuxf3Hw==
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.8.0.tgz#c501f10df72914bb77a458919e79fc73e4a2f9ef"
+  integrity sha512-L+cJ/+pkdICMueKR6wIx3VP2fjIx3yAhuvadUv/osv9yFD7OVZy442xFF+Oeu3ZvmhBGQzoF6mTSt+LUWBmGQg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -2022,12 +2022,12 @@ browserslist@4.16.6:
     node-releases "^1.1.71"
 
 browserslist@^4.17.5:
-  version "4.17.6"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.17.6.tgz#c76be33e7786b497f66cad25a73756c8b938985d"
-  integrity sha512-uPgz3vyRTlEiCv4ee9KlsKgo2V6qPk7Jsn0KAn2OBqbqKo3iNcPEC1Ti6J4dwnz+aIRfEEEuOzC9IBk8tXUomw==
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.18.1.tgz#60d3920f25b6860eb917c6c7b185576f4d8b017f"
+  integrity sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==
   dependencies:
-    caniuse-lite "^1.0.30001274"
-    electron-to-chromium "^1.3.886"
+    caniuse-lite "^1.0.30001280"
+    electron-to-chromium "^1.3.896"
     escalade "^3.1.1"
     node-releases "^2.0.1"
     picocolors "^1.0.0"
@@ -2210,11 +2210,11 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 camelcase@^6.0.0, camelcase@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
-  integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.1.tgz#250fd350cfd555d0d2160b1d51510eaf8326e86e"
+  integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
 
-caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228, caniuse-lite@^1.0.30001274:
+caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228, caniuse-lite@^1.0.30001280:
   version "1.0.30001280"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz#066a506046ba4be34cde5f74a08db7a396718fb7"
   integrity sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA==
@@ -2753,9 +2753,9 @@ cssnano-simple@3.0.0:
     cssnano-preset-simple "^3.0.0"
 
 csstype@^3.0.2:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.9.tgz#6410af31b26bd0520933d02cbc64fce9ce3fbf0b"
-  integrity sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
+  integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
 
 d@1, d@^1.0.1:
   version "1.0.1"
@@ -3118,10 +3118,10 @@ electron-fetch@^1.7.2:
   dependencies:
     encoding "^0.1.13"
 
-electron-to-chromium@^1.3.723, electron-to-chromium@^1.3.886:
-  version "1.3.895"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.895.tgz#9b0f8f2e32d8283bbb200156fd5d8dfd775f31ed"
-  integrity sha512-9Ww3fB8CWctjqHwkOt7DQbMZMpal2x2reod+/lU4b9axO1XJEDUpPMBxs7YnjLhhqpKXIIB5SRYN/B4K0QpvyQ==
+electron-to-chromium@^1.3.723, electron-to-chromium@^1.3.896:
+  version "1.3.897"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.897.tgz#16ddf5943eeec6ae08704b015ecd26b143b03947"
+  integrity sha512-nRNZhAZ7hVCe75jrCUG7xLOqHMwloJMj6GEXEzY4OMahRGgwerAo+ls/qbqUwFH+E20eaSncKkQ4W8KP5SOiAg==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -7961,7 +7961,7 @@ printj@~1.1.0:
   resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
   integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
-prismjs@^1.22.0, prismjs@~1.25.0:
+prismjs@^1.25.0, prismjs@~1.25.0:
   version "1.25.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.25.0.tgz#6f822df1bdad965734b310b315a23315cf999756"
   integrity sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==
@@ -8290,9 +8290,9 @@ react-native-fetch-api@^2.0.0:
     p-defer "^3.0.0"
 
 react-query@^3.13.9:
-  version "3.32.2"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.32.2.tgz#66da144c4b2862f06a679aea3790ccb17f099a4e"
-  integrity sha512-g72+faJAwvYywXNrAbP+Iq5YJJzp94ADWHZMSJPi9I3DZdRDQ76gYi/YLzrA9fE9VZkoKz+OOH321eCsC2GPLQ==
+  version "3.32.3"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.32.3.tgz#a15035d0bcd632fffc7044839469e685c2dbcfc9"
+  integrity sha512-RB/EOSdJkmuypDIARG/mVi2T41WZKz3tUh72HAUu1OA3VoFr2kG2OFZoO3ylMKjUYI4A9bSaD7wtYg4Nwb71gQ==
   dependencies:
     "@babel/runtime" "^7.5.5"
     broadcast-channel "^3.4.1"
@@ -8316,14 +8316,14 @@ react-refresh@0.8.3:
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
 react-syntax-highlighter@^15.4.4:
-  version "15.4.4"
-  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.4.4.tgz#dc9043f19e7bd063ff3ea78986d22a6eaa943b2a"
-  integrity sha512-PsOFHNTzkb3OroXdoR897eKN5EZ6grht1iM+f1lJSq7/L0YVnkJaNVwC3wEUYPOAmeyl5xyer1DjL6MrumO6Zw==
+  version "15.4.5"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.4.5.tgz#db900d411d32a65c8e90c39cd64555bf463e712e"
+  integrity sha512-RC90KQTxZ/b7+9iE6s9nmiFLFjWswUcfULi4GwVzdFVKVMQySkJWBuOmJFfjwjMVCo0IUUuJrWebNKyviKpwLQ==
   dependencies:
     "@babel/runtime" "^7.3.1"
     highlight.js "^10.4.1"
     lowlight "^1.17.0"
-    prismjs "^1.22.0"
+    prismjs "^1.25.0"
     refractor "^3.2.0"
 
 react@17.0.2:
@@ -9079,9 +9079,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz#0d9becccde7003d6c658d487dd48a32f0bf3014b"
-  integrity sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz#50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95"
+  integrity sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==
 
 split2@^3.1.1:
   version "3.2.2"
@@ -9679,6 +9679,11 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+toml@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
+  integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
 
 totalist@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
I think I did it!

This adds a `.devcontainer` folder with a bunch of stuff to enable running all the dependent services using docker-compose.

If you're using VSCode, you should see something like this when you checkout this branch:
<img width="568" alt="Screen Shot 2021-11-13 at 7 23 48 PM" src="https://user-images.githubusercontent.com/678715/141664074-5c0a8670-af53-4fab-9237-82e799562db4.png">

Clicking "reopen in container" should hopefully spin up all the services defined in `.devcontainer/docker-compose.yml`, along with the DB services in `packages/api/docker/docker-compose.yml`, which is symlinked to `.devcontainer/docker-compose.db.yml`.

There's also a `.devcontainer/docker-compose.extend.yml` file that's a placeholder for things you might need to override for your local env. I'm using it because my main dev machine is an M1 mac and dealing with the arch issues is annoying, so I usually run docker stuff using a [docker context](https://docs.docker.com/engine/context/working-with-contexts/) that points to a nearby x86 machine. Remote contexts wont work with bind mounts from the local machine, so my solution is to clone the repo on the remote machine, then put this in my override compose file:

```yaml
services:
  dev:
    volumes:
      - /home/yusef/work/repos/nft.storage:/workspace
```

That way the checked out repo on the remote machine gets bind-mounted into the container, instead of trying to use the local checkout on my mac. This is slightly less convenient, since the remote copy doesn't automatically sync with the local one, but that could be solved with sshfs or something.

I also added a new command to `tools/cli.js` called `local-env-check` that tries to sanity check your `.env` file, make sure you're logged into `wrangler`, and check that all the required wrangler secrets are defined. It doesn't check everything, but it seems like a good start.

The local-env-check should run automatically when you attach to the container in vscode. If you don't have all the right vars, it should complain at you.

If everything's all good, it will tell you to run `node ./packages/api/scripts/cli.js db-sql --cargo --testing` to setup the local db schema.

If you're not using VSCode, you can run `.devcontainer/compose.sh`, which is a wrapper around `docker-compose` that targets the combined compose files. It accepts all the same args as `docker-compose`, so e.g.: `./.devcontainer/compose.sh up`.

Please kick the tires on this and let me know how it works for you!