### PR TITLE
docs: add encodeBlob example

### DIFF
--- a/packages/client/examples/node.js/encodeBlob.js
+++ b/packages/client/examples/node.js/encodeBlob.js
@@ -1,0 +1,20 @@
+import fs from 'fs'
+import { NFTStorage, Blob } from 'nft.storage'
+
+const endpoint = 'https://api.nft.storage' // the default
+const token = 'API_KEY' // your API key from https://nft.storage/manage
+
+async function main() {
+  const storage = new NFTStorage({ endpoint, token })
+  const data = await fs.promises.readFile('pinpie.jpg')
+  const { cid, car } = await NFTStorage.encodeBlob(new Blob([data]))
+  console.log(`File CID: ${cid}`)
+
+  console.log('Sending file...')
+  await storage.storeCar(car, {
+    onStoredChunk: (size) => console.log(`Stored a chunk of ${size} bytes`),
+  })
+
+  console.log('✅ Done')
+}
+main()

--- a/packages/client/examples/node.js/package.json
+++ b/packages/client/examples/node.js/package.json
@@ -12,6 +12,6 @@
   "license": "(Apache-2.0 AND MIT)",
   "dependencies": {
     "ipfs-car": "^0.5.8",
-    "nft.storage": "^3.3.0"
+    "nft.storage": "^4.0.0"
   }
 }


### PR DESCRIPTION
Auto chunking for CAR files shipped https://github.com/nftstorage/nft.storage/pull/588 and I created an example so I could test it out myself manually. May as well PR it for others to see.