### PR TITLE
feat: add X-Client header

### DIFF
--- a/packages/api/src/utils/debug.js
+++ b/packages/api/src/utils/debug.js
@@ -21,7 +21,7 @@ export function debugJson(obj) {
 
 const sentryOptions = {
   dsn: secrets.sentry,
-  allowedHeaders: ['user-agent'],
+  allowedHeaders: ['user-agent', 'x-client'],
   allowedSearchParams: /(.*)/,
   debug: false,
   environment: ENV,

--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -88,7 +88,7 @@ class NFTStorage {
    */
   static auth(token) {
     if (!token) throw new Error('missing token')
-    return { Authorization: `Bearer ${token}` }
+    return { Authorization: `Bearer ${token}`, 'X-Client': 'nft.storage/js' }
   }
 
   /**


### PR DESCRIPTION
Adds an `X-Client` header to the JS client and configures Sentry to accept it.

Closes https://github.com/nftstorage/nft.storage/issues/57