### PR TITLE
fix: do not prefer node.js builtins

### DIFF
--- a/packages/client/rollup.esm.config.js
+++ b/packages/client/rollup.esm.config.js
@@ -18,6 +18,7 @@ export default {
   plugins: [
     commonjs(),
     resolve({
+      preferBuiltins: false,
       browser: true,
     }),
     json(),


### PR DESCRIPTION
Without this option, we get `import require$$0 from"buffer";` in the bundle, which cannot be resolved when used in the browser (what it is for).

<img width="706" alt="Screenshot 2021-12-03 at 15 34 13" src="https://user-images.githubusercontent.com/152863/144629411-20ca19a3-56d9-4e5e-a20c-c1577f37b876.png">