### PR TITLE
chore(website): add info about rate limits to http docs

### DIFF
--- a/packages/website/public/schema.yml
+++ b/packages/website/public/schema.yml
@@ -57,6 +57,10 @@ paths:
         The store endpoint is restricted to a total request body size of 100MB, which includes the metadata and all attached files. To store larger files, you
         can use the /upload endpoint with chunked CAR files (see "/upload").
 
+        ### Rate limits
+
+        This API imposes rate limits to ensure quality of service. You may receive a 429 "Too many requests" error if you make more than 30 requests with the same API token within a ten second window. Upon receiving a response with a 429 status, clients should retry the failed request after a small delay. To avoid 429 responses, you may wish to implement client-side request throttling to stay within the limits.
+
       operationId: store
       requestBody:
         required: true
@@ -119,6 +123,10 @@ paths:
         and queued for storage on Filecoin.
 
         For more about working with CARs, see https://docs.web3.storage/how-tos/work-with-car-files
+
+        ### Rate limits
+
+        This API imposes rate limits to ensure quality of service. You may receive a 429 "Too many requests" error if you make more than 30 requests with the same API token within a ten second window. Upon receiving a response with a 429 status, clients should retry the failed request after a small delay. To avoid 429 responses, you may wish to implement client-side request throttling to stay within the limits.
 
       operationId: upload
       requestBody:


### PR DESCRIPTION
Adds a note about rate limits to the HTTP spec (copied from this similar [w3s PR](https://github.com/web3-storage/docs/pull/216)), but I'm not 100% sure it's accurate, since #877 suggests that we have global limits here instead of per-token limits. 