### PR TITLE
chore(api): add METAPLEX_AUTH_TOKEN to constants.js

### DIFF
--- a/packages/api/src/constants.js
+++ b/packages/api/src/constants.js
@@ -1,4 +1,4 @@
-// let MAGIC_SECRET_KEY, SALT, PINATA_JWT, SENTRY_DSN, DATABASE_TOKEN, CLUSTER_SERVICE, LOGTAIL_TOKEN, MAILCHIMP_API_KEY
+// let MAGIC_SECRET_KEY, SALT, PINATA_JWT, SENTRY_DSN, DATABASE_TOKEN, CLUSTER_SERVICE, LOGTAIL_TOKEN, MAILCHIMP_API_KEY, METAPLEX_AUTH_TOKEN
 
 export const secrets = {
   salt: SALT,
@@ -7,6 +7,7 @@ export const secrets = {
   database: DATABASE_TOKEN,
   mailchimp: MAILCHIMP_API_KEY,
   logtail: LOGTAIL_TOKEN,
+  metaplexAuth: METAPLEX_AUTH_TOKEN,
 }
 
 const CLUSTER1 = 'https://nft.storage.ipfscluster.io/api/'

--- a/packages/api/src/routes/metaplex-upload.js
+++ b/packages/api/src/routes/metaplex-upload.js
@@ -15,6 +15,7 @@ import {
   ErrorMetaplexTokenNotFound,
   ErrorInvalidMetaplexToken,
 } from '../errors.js'
+import { secrets } from '../constants.js'
 
 /**
  * When >2.5MB, use local add, because waiting for blocks to be sent to
@@ -79,7 +80,7 @@ export async function metaplexUpload(event, ctx) {
  * @returns
  */
 async function validate(db) {
-  if (typeof METAPLEX_AUTH_TOKEN === 'undefined') {
+  if (!secrets.metaplexAuth) {
     throw new Error('missing metaplex auth key')
   }
   // note: we need to specify the foreign key to use in the select statement below
@@ -88,7 +89,7 @@ async function validate(db) {
   const { error, data } = await db.client
     .from('auth_key')
     .select('id,user:auth_key_user_id_fkey(id)')
-    .eq('secret', METAPLEX_AUTH_TOKEN)
+    .eq('secret', secrets.metaplexAuth)
     .single()
 
   if (error) {


### PR DESCRIPTION
This stores the value of the `METAPLEX_AUTH_TOKEN` global in `secrets.metaplexAuth` in constants.js to be more consistent with the rest of the code.
