### PR TITLE
feat(api): add mintingAgent tag to metaplex token

### DIFF
--- a/packages/api/src/routes/metaplex-upload.js
+++ b/packages/api/src/routes/metaplex-upload.js
@@ -177,9 +177,7 @@ async function parseMetaplexJWT(token) {
     throw new ErrorInvalidMetaplexToken('tags not present in payload')
   }
 
-  // Temporarily accept old kebab-case name for solanaCluster tag.
-  const solanaCluster =
-    payload.req.put.tags.solanaCluster || payload.req.put.tags['solana-cluster']
+  const solanaCluster = payload.req.put.tags.solanaCluster
   if (typeof solanaCluster !== 'string') {
     throw new ErrorInvalidMetaplexToken(
       '"solanaCluster" tag not present in payload'

--- a/packages/api/src/routes/metaplex-upload.js
+++ b/packages/api/src/routes/metaplex-upload.js
@@ -177,7 +177,9 @@ async function parseMetaplexJWT(token) {
     throw new ErrorInvalidMetaplexToken('tags not present in payload')
   }
 
-  const solanaCluster = payload.req.put.tags.solanaCluster
+  // temporarily support old kebab-case tag name
+  const solanaCluster =
+    payload.req.put.tags.solanaCluster || payload.req.put.tags['solana-cluster']
   if (typeof solanaCluster !== 'string') {
     throw new ErrorInvalidMetaplexToken(
       '"solanaCluster" tag not present in payload'
@@ -185,9 +187,9 @@ async function parseMetaplexJWT(token) {
   }
 
   const { mintingAgent, agentVersion } = payload.req.put.tags
-  if (typeof mintingAgent !== 'string') {
+  if (mintingAgent && typeof mintingAgent !== 'string') {
     throw new ErrorInvalidMetaplexToken(
-      '"mintingAgent" tag not present in payload'
+      '"mintingAgent" tag must have a string value if present'
     )
   }
 
@@ -203,7 +205,7 @@ async function parseMetaplexJWT(token) {
     iss,
     rootCID,
     solanaCluster,
-    mintingAgent,
+    mintingAgent: mintingAgent || 'unknown',
     agentVersion,
   }
 }

--- a/packages/api/test/metaplex-upload.spec.js
+++ b/packages/api/test/metaplex-upload.spec.js
@@ -113,7 +113,6 @@ describe('Metaplex Upload', () => {
       rootCID: fixture.meta.req.put.rootCID,
       solanaCluster: fixture.meta.req.put.tags['solana-cluster'],
       mintingAgent: 'unknown',
-      agentVersion: undefined,
     }
     assert.deepEqual(data.meta, expectedMeta, 'metadata matches jwt payload')
   })

--- a/packages/api/test/metaplex-upload.spec.js
+++ b/packages/api/test/metaplex-upload.spec.js
@@ -24,6 +24,7 @@ describe('Metaplex Upload', () => {
     const cid = 'bafkreifeqjorwymdmh77ars6tbrtno74gntsdcvqvcycucidebiri2e7qy'
     assert.strictEqual(root.toString(), cid, 'car file has correct root')
 
+    // @ts-ignore
     const fixture = fixtures.metaplexAuth[cid]
     assert.notEqual(fixture, null, 'no fixture for cid ' + cid)
 
@@ -68,13 +69,63 @@ describe('Metaplex Upload', () => {
     assert.deepEqual(data.meta, expectedMeta, 'metadata matches jwt payload')
   })
 
+  it('should support payloads without mintingAgent tag', async () => {
+    const { root, car } = await createCar('hello again')
+    // expected CID for the above data
+    const cid = 'bafkreifeqjorwymdmh77ars6tbrtno74gntsdcvqvcycucidebiri2e7qy'
+    assert.strictEqual(root.toString(), cid, 'car file has correct root')
+
+    const fixture = fixtures.metaplexAuth.v0[cid]
+    assert.notEqual(fixture, null, 'no fixture for cid ' + cid)
+
+    const res = await fetch('metaplex/upload', {
+      method: 'POST',
+      headers: {
+        'x-web3auth': `Metaplex ${fixture.token}`,
+        'Content-Type': 'application/car',
+      },
+      body: car,
+    })
+
+    assert(res, 'Server responded')
+    assert(res.ok, 'Server response ok')
+    const { ok, value } = await res.json()
+    assert(ok, 'Server response payload has `ok` property')
+    assert.strictEqual(value.cid, cid, 'Server responded with expected CID')
+    assert.strictEqual(
+      value.type,
+      'application/car',
+      'type should match blob mime-type'
+    )
+
+    const { data } = await rawClient
+      .from('upload')
+      .select('*, content(*)')
+      .match({ source_cid: cid, user_id: client.userId })
+      .single()
+
+    // @ts-ignore
+    assert.equal(data.source_cid, cid)
+    assert.equal(data.deleted_at, null)
+    assert.equal(data.content.dag_size, 15, 'correct dag size')
+
+    const expectedMeta = {
+      iss: fixture.meta.iss,
+      rootCID: fixture.meta.req.put.rootCID,
+      solanaCluster: fixture.meta.req.put.tags['solana-cluster'],
+      mintingAgent: 'unknown',
+      agentVersion: undefined,
+    }
+    assert.deepEqual(data.meta, expectedMeta, 'metadata matches jwt payload')
+  })
+
   it('should fail if token has an invalid signature', async () => {
     const { root, car } = await createCar('hello world car')
     // expected CID for the above data
     const cid = 'bafkreifeqjorwymdmh77ars6tbrtno74gntsdcvqvcycucidebiri2e7qy'
     assert.strictEqual(root.toString(), cid, 'car file has correct root')
 
-    const fixture = fixtures.metaplexAuth[cid]
+    const fixture = fixtures.metaplexAuth.v1[cid]
     assert.notEqual(fixture, null, 'no fixture for cid ' + cid)
 
     const tokenParts = fixture.token.split('.')
@@ -100,7 +151,7 @@ describe('Metaplex Upload', () => {
     const cid = 'bafkreifeqjorwymdmh77ars6tbrtno74gntsdcvqvcycucidebiri2e7qy'
     assert.strictEqual(root.toString(), cid, 'car file has correct root')
 
-    const fixture = fixtures.metaplexAuth[cid]
+    const fixture = fixtures.metaplexAuth.v1[cid]
     assert.notEqual(fixture, null, 'no fixture for cid ' + cid)
 
     const tokenParts = fixture.token.split('.')
@@ -124,7 +175,7 @@ describe('Metaplex Upload', () => {
     // cid for the "hello world car". we have a valid token saved for this CID as a fixture
     const signedCID =
       'bafkreifeqjorwymdmh77ars6tbrtno74gntsdcvqvcycucidebiri2e7qy'
-    const fixture = fixtures.metaplexAuth[signedCID]
+    const fixture = fixtures.metaplexAuth.v1[signedCID]
     assert.notEqual(fixture, null, 'no fixture for cid ' + signedCID)
 
     const { root, car } = await createCar('a different car')

--- a/packages/api/test/metaplex-upload.spec.js
+++ b/packages/api/test/metaplex-upload.spec.js
@@ -61,7 +61,9 @@ describe('Metaplex Upload', () => {
     const expectedMeta = {
       iss: fixture.meta.iss,
       rootCID: fixture.meta.req.put.rootCID,
-      solanaCluster: fixture.meta.req.put.tags['solana-cluster'],
+      solanaCluster: fixture.meta.req.put.tags.solanaCluster,
+      mintingAgent: fixture.meta.req.put.tags.mintingAgent,
+      agentVersion: fixture.meta.req.put.tags.agentVersion,
     }
     assert.deepEqual(data.meta, expectedMeta, 'metadata matches jwt payload')
   })

--- a/packages/api/test/metaplex-upload.spec.js
+++ b/packages/api/test/metaplex-upload.spec.js
@@ -24,8 +24,7 @@ describe('Metaplex Upload', () => {
     const cid = 'bafkreifeqjorwymdmh77ars6tbrtno74gntsdcvqvcycucidebiri2e7qy'
     assert.strictEqual(root.toString(), cid, 'car file has correct root')
 
-    // @ts-ignore
-    const fixture = fixtures.metaplexAuth[cid]
+    const fixture = fixtures.metaplexAuth.v1[cid]
     assert.notEqual(fixture, null, 'no fixture for cid ' + cid)
 
     const res = await fetch('metaplex/upload', {

--- a/packages/api/test/metaplex-upload.spec.js
+++ b/packages/api/test/metaplex-upload.spec.js
@@ -69,7 +69,7 @@ describe('Metaplex Upload', () => {
   })
 
   it('should support payloads without mintingAgent tag', async () => {
-    const { root, car } = await createCar('hello again')
+    const { root, car } = await createCar('hello world car')
     // expected CID for the above data
     const cid = 'bafkreifeqjorwymdmh77ars6tbrtno74gntsdcvqvcycucidebiri2e7qy'
     assert.strictEqual(root.toString(), cid, 'car file has correct root')

--- a/packages/api/test/scripts/fixtures.js
+++ b/packages/api/test/scripts/fixtures.js
@@ -18,24 +18,48 @@ export const fixtures = {
   ],
 
   metaplexAuth: {
-    bafkreifeqjorwymdmh77ars6tbrtno74gntsdcvqvcycucidebiri2e7qy: {
-      meta: {
-        iss: 'did:key:z6Mkh74NGBSqQGqeKa2wVuJyRJ1ZJwPngHPg9V6DY2qnVnA5',
-        req: {
-          put: {
-            rootCID:
-              'bafkreifeqjorwymdmh77ars6tbrtno74gntsdcvqvcycucidebiri2e7qy',
-            tags: {
-              chain: 'solana',
-              solanaCluster: 'devnet',
-              mintingAgent: 'metaplex-auth/cli',
-              agentVersion: '0.2.3',
+    // Tokens made before mintingAgent tag was introduced, with old solana-cluster tag name
+    v0: {
+      bafkreifeqjorwymdmh77ars6tbrtno74gntsdcvqvcycucidebiri2e7qy: {
+        meta: {
+          iss: 'did:key:z6Mkh74NGBSqQGqeKa2wVuJyRJ1ZJwPngHPg9V6DY2qnVnA5',
+          req: {
+            put: {
+              rootCID:
+                'bafkreifeqjorwymdmh77ars6tbrtno74gntsdcvqvcycucidebiri2e7qy',
+              tags: {
+                chain: 'solana',
+                'solana-cluster': 'devnet',
+              },
             },
           },
         },
+        token:
+          'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWtoNzROR0JTcVFHcWVLYTJ3VnVKeVJKMVpKd1BuZ0hQZzlWNkRZMnFuVm5BNSIsInJlcSI6eyJwdXQiOnsicm9vdENJRCI6ImJhZmtyZWlmZXFqb3J3eW1kbWg3N2FyczZ0YnJ0bm83NGdudHNkY3ZxdmN5Y3VjaWRlYmlyaTJlN3F5IiwidGFncyI6eyJjaGFpbiI6InNvbGFuYSIsInNvbGFuYS1jbHVzdGVyIjoiZGV2bmV0In19fX0.V84TeeEbxHa78di8VONueLjPwk_VpFeWvPs70gIvNmedsUnsfG9DPRSi2FLv3wo3vc1PdjdGnvj0ql9dY6hHCA',
       },
-      token:
-        'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWtoNzROR0JTcVFHcWVLYTJ3VnVKeVJKMVpKd1BuZ0hQZzlWNkRZMnFuVm5BNSIsInJlcSI6eyJwdXQiOnsicm9vdENJRCI6ImJhZmtyZWlmZXFqb3J3eW1kbWg3N2FyczZ0YnJ0bm83NGdudHNkY3ZxdmN5Y3VjaWRlYmlyaTJlN3F5IiwidGFncyI6eyJjaGFpbiI6InNvbGFuYSIsInNvbGFuYUNsdXN0ZXIiOiJkZXZuZXQiLCJtaW50aW5nQWdlbnQiOiJtZXRhcGxleC1hdXRoL2NsaSIsImFnZW50VmVyc2lvbiI6IjAuMi4zIn19fX0.03fldV7VjGWnqgVQDj3HypOztOwiZsW3hIic4t1z5Ei00Q6336srZS6EyXsQHXez8sWIDHGBnMWPLqb6aGr3AA',
+    },
+
+    // Tokens made with mintingAgent tag, using "solanaCluster" tag name
+    v1: {
+      bafkreifeqjorwymdmh77ars6tbrtno74gntsdcvqvcycucidebiri2e7qy: {
+        meta: {
+          iss: 'did:key:z6Mkh74NGBSqQGqeKa2wVuJyRJ1ZJwPngHPg9V6DY2qnVnA5',
+          req: {
+            put: {
+              rootCID:
+                'bafkreifeqjorwymdmh77ars6tbrtno74gntsdcvqvcycucidebiri2e7qy',
+              tags: {
+                chain: 'solana',
+                solanaCluster: 'devnet',
+                mintingAgent: 'metaplex-auth/cli',
+                agentVersion: '0.2.3',
+              },
+            },
+          },
+        },
+        token:
+          'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWtoNzROR0JTcVFHcWVLYTJ3VnVKeVJKMVpKd1BuZ0hQZzlWNkRZMnFuVm5BNSIsInJlcSI6eyJwdXQiOnsicm9vdENJRCI6ImJhZmtyZWlmZXFqb3J3eW1kbWg3N2FyczZ0YnJ0bm83NGdudHNkY3ZxdmN5Y3VjaWRlYmlyaTJlN3F5IiwidGFncyI6eyJjaGFpbiI6InNvbGFuYSIsInNvbGFuYUNsdXN0ZXIiOiJkZXZuZXQiLCJtaW50aW5nQWdlbnQiOiJtZXRhcGxleC1hdXRoL2NsaSIsImFnZW50VmVyc2lvbiI6IjAuMi4zIn19fX0.03fldV7VjGWnqgVQDj3HypOztOwiZsW3hIic4t1z5Ei00Q6336srZS6EyXsQHXez8sWIDHGBnMWPLqb6aGr3AA',
+      },
     },
   },
 }

--- a/packages/api/test/scripts/fixtures.js
+++ b/packages/api/test/scripts/fixtures.js
@@ -25,12 +25,17 @@ export const fixtures = {
           put: {
             rootCID:
               'bafkreifeqjorwymdmh77ars6tbrtno74gntsdcvqvcycucidebiri2e7qy',
-            tags: { chain: 'solana', 'solana-cluster': 'devnet' },
+            tags: {
+              chain: 'solana',
+              solanaCluster: 'devnet',
+              mintingAgent: 'metaplex-auth/cli',
+              agentVersion: '0.2.3',
+            },
           },
         },
       },
       token:
-        'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWtoNzROR0JTcVFHcWVLYTJ3VnVKeVJKMVpKd1BuZ0hQZzlWNkRZMnFuVm5BNSIsInJlcSI6eyJwdXQiOnsicm9vdENJRCI6ImJhZmtyZWlmZXFqb3J3eW1kbWg3N2FyczZ0YnJ0bm83NGdudHNkY3ZxdmN5Y3VjaWRlYmlyaTJlN3F5IiwidGFncyI6eyJjaGFpbiI6InNvbGFuYSIsInNvbGFuYS1jbHVzdGVyIjoiZGV2bmV0In19fX0.V84TeeEbxHa78di8VONueLjPwk_VpFeWvPs70gIvNmedsUnsfG9DPRSi2FLv3wo3vc1PdjdGnvj0ql9dY6hHCA',
+        'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWtoNzROR0JTcVFHcWVLYTJ3VnVKeVJKMVpKd1BuZ0hQZzlWNkRZMnFuVm5BNSIsInJlcSI6eyJwdXQiOnsicm9vdENJRCI6ImJhZmtyZWlmZXFqb3J3eW1kbWg3N2FyczZ0YnJ0bm83NGdudHNkY3ZxdmN5Y3VjaWRlYmlyaTJlN3F5IiwidGFncyI6eyJjaGFpbiI6InNvbGFuYSIsInNvbGFuYUNsdXN0ZXIiOiJkZXZuZXQiLCJtaW50aW5nQWdlbnQiOiJtZXRhcGxleC1hdXRoL2NsaSIsImFnZW50VmVyc2lvbiI6IjAuMi4zIn19fX0.03fldV7VjGWnqgVQDj3HypOztOwiZsW3hIic4t1z5Ei00Q6336srZS6EyXsQHXez8sWIDHGBnMWPLqb6aGr3AA',
     },
   },
 }


### PR DESCRIPTION
This updates the metaplex endpoint to require a `mintingAgent` tag (added in https://github.com/nftstorage/metaplex-auth/pull/22), and pulls the `agentVersion` tag out of the payload if it's present.

The metaplex-auth PR above also changes the name of the `solana-cluster` tag to `solanaCluster`, since I originally used kebab-case for some reason and now regret my life choices. So this PR updates the backend to read the new tag. I was thinking we could briefly support both, but since we don't have any real traffic here yet it seems alright to just make the breaking change, especially since requests made with the old version would fail anyway due to the missing `mintingAgent` tag.

