### PR TITLE
chore(api): update postgrest docker image to v9.0.0

### DIFF
--- a/packages/api/db/docker/docker-compose.yml
+++ b/packages/api/db/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   rest:
-    image: postgrest/postgrest:v8.0.0
+    image: postgrest/postgrest:v9.0.0
     depends_on:
       - db
     restart: always


### PR DESCRIPTION
My M1 Mac wasn't able to run the API tests because the `postgrest` image didn't have an ARM variant, and it wasn't working with the X86 emulation. Just yesterday though, v9.0.0 was released and an ARM variant was published to docker hub.

Now I can run the tests locally instead of pushing a bunch of "fix test (for real this time)" commits up to CI 😛 
