### PR TITLE
docs: add cidv0 example

### DIFF
--- a/packages/client/examples/node.js/old-cidv0.js
+++ b/packages/client/examples/node.js/old-cidv0.js
@@ -1,0 +1,41 @@
+/**
+ * A v0 CID can be obtained by downgrading a v1 CID of a DAG that is created
+ * _without raw leaf nodes_.
+ *
+ * The client does not support this _directly_, but you can create a CAR file
+ * with a DAG that does _not_ have raw leaf nodes using the ipfs-car module and
+ * then pass the result to the `storeCar` method of the client.
+ */
+import { NFTStorage, Blob } from 'nft.storage'
+import { packToBlob } from 'ipfs-car/pack/blob'
+import * as fs from 'fs'
+
+const endpoint = 'https://api.nft.storage' // the default
+const token = process.env.API_KEY // your API key from https://nft.storage/manage
+
+async function main() {
+  await storeBlobV0()
+}
+
+async function storeBlobV0() {
+  const storage = new NFTStorage({ endpoint, token })
+  const data = await fs.promises.readFile('pinpie.jpg')
+
+  // create a CAR with a DAG that does not have raw leaf nodes
+  const { root, car } = await packToBlob({
+    input: new Blob([data]),
+    rawLeaves: false,
+    wrapWithDirectory: false,
+  })
+  await storage.storeCar(car)
+
+  // downgrade the CID to v0
+  const cidV0 = root.toV0()
+  console.log({ cid: cidV0.toString() })
+
+  // the v0 CID can even be used in the /check API
+  const status = await storage.check(cidV0)
+  console.log(status)
+}
+
+main()

--- a/packages/client/examples/node.js/old-cidv0.js
+++ b/packages/client/examples/node.js/old-cidv0.js
@@ -3,8 +3,12 @@
  * _without raw leaf nodes_.
  *
  * The client does not support this _directly_, but you can create a CAR file
- * with a DAG that does _not_ have raw leaf nodes using the ipfs-car module and
- * then pass the result to the `storeCar` method of the client.
+ * with a DAG that does _not_ have raw leaf nodes using the ipfs-car module,
+ * pass the result to the `storeCar` method of the client and then downgrade the
+ * v1 CID to a v0 CID.
+ *
+ * ⚠️ Note that in the files listing returned from the API the v1 CID will be
+ * referenced.
  */
 import { NFTStorage, Blob } from 'nft.storage'
 import { packToBlob } from 'ipfs-car/pack/blob'
@@ -32,6 +36,7 @@ async function storeBlobV0() {
   // downgrade the CID to v0
   const cidV0 = root.toV0()
   console.log({ cid: cidV0.toString() })
+  // { cid: 'QmcLaoGJd1rAF1i7Q5Q4YknSuoC6eyFRFBaNXVRyANn1tA' }
 
   // the v0 CID can even be used in the /check API
   const status = await storage.check(cidV0)

--- a/packages/client/examples/node.js/package.json
+++ b/packages/client/examples/node.js/package.json
@@ -11,7 +11,7 @@
   "author": "Alan Shaw",
   "license": "(Apache-2.0 AND MIT)",
   "dependencies": {
-    "ipfs-car": "^0.5.8",
-    "nft.storage": "^4.0.0"
+    "ipfs-car": "^0.6.1",
+    "nft.storage": "^5.1.3"
   }
 }


### PR DESCRIPTION
`ipfs-car@0.6.1` now supports the `rawLeaves` option.

It means that if absolutely necessary, a v0 CID can be obtained for a DAG by downgrading the CID returned from the library (note this is only possible by using `rawLeaves: false`).

How far do we want to go with this? We could stop here, or we could add it as an option to the client that `encodeDirectory` and `encodeBlob` might take - the example becomes simplier but we'll need to release a new version of the client. My gut instinct is to leave it like this.