### PR TITLE
fix: make @ipld/dag-cbor a dependency of nft.storage

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@ipld/car": "^3.1.20",
+    "@ipld/dag-cbor": "^6.0.13",
     "@web-std/blob": "^3.0.1",
     "@web-std/fetch": "^3.0.0",
     "@web-std/file": "^3.0.0",
@@ -58,7 +59,6 @@
     "streaming-iterables": "^6.0.0"
   },
   "devDependencies": {
-    "@ipld/dag-cbor": "^6.0.13",
     "@ipld/dag-json": "8.0.4",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-json": "^4.1.0",


### PR DESCRIPTION
`@ipld/dag-cbor` is directly used in src/token.js, so it should be a dependency, not a devDependency. This fixes an error that yarn pnp raises due to accessing an undeclared dependency.