### PR TITLE
chore: updated dag to to not be restricted

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -59,7 +59,7 @@
     "streaming-iterables": "^6.0.0"
   },
   "devDependencies": {
-    "@ipld/dag-json": "8.0.4",
+    "@ipld/dag-json": "^8.0.4",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.0.0",


### PR DESCRIPTION
chore: updated dag to to not be restricted
Fixes #950 unlocks the version of @ipld/dag-json