### PR TITLE
fix: install instructions

### DIFF
--- a/packages/website/pages/index.js
+++ b/packages/website/pages/index.js
@@ -426,7 +426,7 @@ console.log(metadata.url)
               :
             </p>
             <pre className="f6 lh-copy white bg-nsnavy pa3 br1 ba b--black code overflow-x-scroll">
-              npm install NFT.Storage
+              npm install nft.storage
             </pre>
             <p className="lh-copy">Use the client in Node.js or the browser:</p>
             <pre className="f6 lh-copy white bg-nsnavy pa3 br1 ba b--black code overflow-x-scroll">


### PR DESCRIPTION
I am not sure if npm is case sensitive in all cases, but the incorrect case caused the issue for me at least.

The correct line to install npm package is:
`npm install nft.storage`
not:
```
$ npm install NFT.Storage
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/NFT.Storage - Not found
npm ERR! 404 
npm ERR! 404  'NFT.Storage@latest' is not in the npm registry.
npm ERR! 404 Your package name is not valid, because 
npm ERR! 404  1. name can no longer contain capital letters
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
```