### PR TITLE
fix: error code for empty multipart data

### DIFF
--- a/packages/api/src/cluster.js
+++ b/packages/api/src/cluster.js
@@ -48,7 +48,8 @@ export async function addDirectory(files, options = {}) {
   const size = files.reduce((total, f) => total + f.size, 0)
   if (size === 0) {
     throw new HTTPError(
-      'Content added contains 0 bytes. Please make sure that files are encoded correctly'
+      'Content added contains 0 bytes. Please make sure that files are encoded correctly',
+      400
     )
   }
 


### PR DESCRIPTION
When a bad request happens with an empty multipart form, we should return 400 Error instead of 500. This was resulting in alerts for bad usage to be filled in in Sentry and alerts being triggered