### PR TITLE
feat: psa allowlist

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -124,6 +124,7 @@ wrangler secret put CLUSTER_BASIC_AUTH_TOKEN --env production # Get from nft.sto
 wrangler secret put CLUSTER_SERVICE --env production # Which cluster should be used. Options 'IpfsCluster' or 'IpfsCluster2'
 wrangler secret put MAILCHIMP_API_KEY --env production # Get from mailchimp
 wrangler secret put LOGTAIL_TOKEN --env production # Get from Logtail
+wrangler secret put PSA_ALLOW --env production # Get from 1password vault
 
 wrangler publish --env production
 ```

--- a/packages/api/src/bindings.d.ts
+++ b/packages/api/src/bindings.d.ts
@@ -23,6 +23,7 @@ declare global {
   const COMMITHASH: string
   const MAINTENANCE_MODE: Mode
   const METAPLEX_AUTH_TOKEN: string
+  const PSA_ALLOW: string
 }
 
 export interface RouteContext {

--- a/packages/api/src/constants.js
+++ b/packages/api/src/constants.js
@@ -46,3 +46,10 @@ export const database = {
 }
 
 export const isDebug = DEBUG === 'true'
+
+/**
+ * The list of user IDs that are allowed to use the Pinning Service API. By
+ * default ["*"] - meaning anyone can use it.
+ */
+export const psaAllow =
+  typeof PSA_ALLOW !== 'undefined' ? PSA_ALLOW.split(',') : ['*']

--- a/packages/api/src/errors.js
+++ b/packages/api/src/errors.js
@@ -161,3 +161,14 @@ export class ErrorInvalidMetaplexToken extends Error {
 }
 
 ErrorInvalidMetaplexToken.CODE = 'ERROR_INVALID_METAPLEX_TOKEN'
+
+export class ErrorPinningUnauthorized extends HTTPError {
+  constructor(
+    msg = 'Pinning not authorized for this user, email support@nft.storage to request authorization.'
+  ) {
+    super(msg, 401)
+    this.name = 'PinningUnauthorized'
+    this.code = ErrorPinningUnauthorized.CODE
+  }
+}
+ErrorPinningUnauthorized.CODE = 'ERROR_PINNING_UNAUTHORIZED'

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -29,7 +29,7 @@ import {
   DEFAULT_MODE,
   setMaintenanceModeGetter,
 } from './middleware/maintenance.js'
-import { withPsaErrorHandler } from './middleware/psa.js'
+import { withPsaErrorHandler, withPinningAuthorized } from './middleware/psa.js'
 import { cluster } from './constants.js'
 import { getContext } from './utils/context.js'
 
@@ -73,7 +73,8 @@ r.add(
  * @param {import('./middleware/maintenance').Mode} mode
  * @returns {import('./bindings').Handler}
  */
-const psa = (handler, mode) => withPsaErrorHandler(withMode(handler, mode))
+const psa = (handler, mode) =>
+  withPsaErrorHandler(withPinningAuthorized(withMode(handler, mode)))
 
 // Login
 r.add('post', '/login', withMode(login, RO), [postCors])

--- a/packages/api/src/middleware/psa.js
+++ b/packages/api/src/middleware/psa.js
@@ -1,11 +1,14 @@
-import { maybeCapture } from '../errors.js'
+import { maybeCapture, ErrorPinningUnauthorized } from '../errors.js'
 import { JSONResponse } from '../utils/json-response.js'
+import { validate } from '../utils/auth.js'
+import { psaAllow } from '../constants.js'
+
+/** @typedef {import('../bindings').Handler} Handler */
 
 /**
  * Catch an error and respond with a response as required by the PSA spec,
  * logging the actual error with sentry.
  *
- * @typedef {import('../bindings').Handler} Handler
  * @param {Handler} handler
  * @returns {Handler}
  */
@@ -25,5 +28,23 @@ export function withPsaErrorHandler(handler) {
         { status }
       )
     }
+  }
+}
+
+/**
+ * Verify that the authenticated request is for a user who is authorized to pin.
+ *
+ * @param {Handler} handler
+ * @returns {Handler}
+ */
+export function withPinningAuthorized(handler) {
+  return async (event, ctx) => {
+    // TODO: we need withAuth middleware so we don't have to do this twice
+    const { user } = await validate(event, ctx)
+    const authorized = psaAllow.includes(String(user.id)) || psaAllow[0] === '*'
+    if (!authorized) {
+      throw new ErrorPinningUnauthorized()
+    }
+    return handler(event, ctx)
   }
 }

--- a/packages/api/src/middleware/psa.js
+++ b/packages/api/src/middleware/psa.js
@@ -32,7 +32,8 @@ export function withPsaErrorHandler(handler) {
 }
 
 /**
- * Verify that the authenticated request is for a user who is authorized to pin.
+ * Verify that the authenticated request is for a user who is authorized to use
+ * the Pinning Service API.
  *
  * @param {Handler} handler
  * @returns {Handler}


### PR DESCRIPTION
Here's a MVP for an allowlist for the pinning service API. Set a global var called `PSA_ALLOW` with user IDs (CSV) of users allowed to use the API. If the variable is not set we allow everyone.

resolves https://github.com/nftstorage/nft.storage/issues/319
resolves https://github.com/nftstorage/nft.storage/issues/148