### PR TITLE
fix: image positioning and use high-res for new blog entry

### DIFF
--- a/packages/website/pages/blog/post/[slug].js
+++ b/packages/website/pages/blog/post/[slug].js
@@ -74,7 +74,7 @@ const Post = ({ post }) => {
         <img
           src={post.meta.thumbnail}
           alt={`Banner for ${post.meta.title}`}
-          className="h-card w-100 object-cover object-top"
+          className="h-card object-cover object-center"
         />
         <div className="mt14 mw7 ph8">
           <div className="post-meta mb4">

--- a/packages/website/posts/2022-01-05-mikeal-modern-finance.mdx
+++ b/packages/website/posts/2022-01-05-mikeal-modern-finance.mdx
@@ -2,7 +2,7 @@
 title: '@mikeal on Modern Finance'
 description: Listen to @mikeal on Kevin Rose's Modern Finance podcast
 author: David Choi
-thumbnail: https://user-images.githubusercontent.com/87873179/146266410-dac03a35-dff7-461b-8096-254f04e5df04.jpg
+thumbnail: https://user-images.githubusercontent.com/87873179/148423075-7b022692-905f-45e4-a7b0-c97f76fce0d5.jpg
 date: Jan 05, 2021
 tags:
   - podcast


### PR DESCRIPTION
addresses #1040
will center position the blog images and prevent them from automatically being 100% if the desired width is not added to avoid upscale and crop issues
before:
<img width="1722" alt="Screen Shot 2022-01-06 at 12 40 37 PM" src="https://user-images.githubusercontent.com/1189523/148448975-fc26570c-53c3-40c4-9753-be730f40a3f1.png">
after:
<img width="1726" alt="fixed-screenshot" src="https://user-images.githubusercontent.com/1189523/148449193-de6db374-908f-449e-b283-57bf4cdc0b5b.png">

NOTE: the new image will accommodate a wide full width banner assuming that the artwork is setup that wide. I'd recommend designing with an art board using 3072 x 800 (double size for retina screens) with 1600px wide centered main area which will serve as the thumbnail on cards.