### PR TITLE
fix: value when metric is missing in db

### DIFF
--- a/packages/api/src/routes/metrics.js
+++ b/packages/api/src/routes/metrics.js
@@ -39,7 +39,7 @@ async function exportPromMetrics(db) {
   return [
     '# HELP nftstorage_users_total Total users registered.',
     '# TYPE nftstorage_users_total counter',
-    `nftstorage_users_total ${usersTotal}`,
+    `nftstorage_users_total ${usersTotal || 0}`,
 
     '# HELP nftstorage_uploads_total Total number of uploads by type.',
     '# TYPE nftstorage_uploads_total counter',

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -15,7 +15,8 @@
     "start:pins": "node src/bin/pins.js",
     "start:pins-failed": "node src/bin/pins-failed.js",
     "start:pinata": "node src/bin/pinata.js",
-    "start:dagcargo:sizes": "NODE_TLS_REJECT_UNAUTHORIZED=0 node src/bin/dagcargo-sizes.js"
+    "start:dagcargo:sizes": "NODE_TLS_REJECT_UNAUTHORIZED=0 node src/bin/dagcargo-sizes.js",
+    "start:metrics": "NODE_TLS_REJECT_UNAUTHORIZED=0 node src/bin/metrics.js"
   },
   "author": "Alan Shaw",
   "license": "(Apache-2.0 OR MIT)",


### PR DESCRIPTION
<img width="424" alt="Screenshot 2022-01-11 at 13 48 24" src="https://user-images.githubusercontent.com/152863/148954471-36fd6312-1013-466d-abb9-e00bf43e04eb.png">

...also adds the missing "start:metrics" script 🤦 