### PR TITLE
fix: query cluster 3 for status

### DIFF
--- a/packages/cron/src/jobs/pins.js
+++ b/packages/cron/src/jobs/pins.js
@@ -148,7 +148,7 @@ async function updatePinStatuses(config) {
 
       switch (pin.service) {
         case 'IpfsCluster':
-          statusRes = await cluster1.status(pin.content_cid)
+          statusRes = await cluster3.status(pin.content_cid)
           break
         case 'IpfsCluster2':
           statusRes = await cluster2.status(pin.content_cid)


### PR DESCRIPTION
Content from Cluster 1 has been moved to Cluster 3.

When cluster 2 has finished transferring we'll migrate the database, but this will get the pin cron job moving until then.