### PR TITLE
feat: add discord and twitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-# [nft.storage](https://nft.storage) <!-- omit in toc -->
+<h1 align="center">
+  <a href="https://nft.storage"><img width="75%" src="https://nft.storage/images/logo-nft.storage.svg" alt="NFT.Storage logo" /></a>
+</h1>
 
-Free decentralized storage and bandwidth for NFTs on IPFS and Filecoin.
+<h3 align="center">Free decentralized storage and bandwidth for NFTs on IPFS and Filecoin.</h3>
 
-<a href="https://nft.storage"><img src="https://raw.githubusercontent.com/nftstorage/nft.storage/main/screenshot.png" alt="nft.storage screenshot" /></a>
+<p align="center">
+  <a href="https://discord.com/channels/806902334369824788/831502708082081822"><img src="https://img.shields.io/badge/chat-discord?style=for-the-badge&logo=discord&label=discord&logoColor=ffffff&color=7389D8" /></a>
+  <a href="https://twitter.com/nft_storage"><img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/nft_storage?color=00aced&label=twitter&logo=twitter&style=for-the-badge"></a>
+</p>
 
 # Table of Contents <!-- omit in toc -->
 


### PR DESCRIPTION
Updates the README, adding badges that link to our discord channel and twitter account. Preview:

<img width="1392" alt="Screenshot 2022-01-18 at 16 00 33" src="https://user-images.githubusercontent.com/152863/149973093-584e0ed5-77b3-4459-bd69-7b4cbfe1374c.png">

<img width="1392" alt="Screenshot 2022-01-18 at 16 00 44" src="https://user-images.githubusercontent.com/152863/149973114-7eaccf38-2861-4b38-b758-24db21055454.png">

refs #1102