### PR TITLE
perf: add indexes for pins and metrics cron improvements

### DIFF
--- a/packages/api/db/tables.sql
+++ b/packages/api/db/tables.sql
@@ -100,6 +100,7 @@ CREATE TABLE IF NOT EXISTS pin
 );
 
 CREATE INDEX IF NOT EXISTS pin_updated_at_idx ON pin (updated_at);
+CREATE INDEX IF NOT EXISTS pin_composite_service_and_status_idx ON pin (service, status);
 CREATE INDEX IF NOT EXISTS pin_composite_pinned_at_idx ON pin (content_cid, updated_at) WHERE status = 'Pinned';
 
 -- An upload created by a user.
@@ -136,6 +137,7 @@ CREATE TABLE IF NOT EXISTS upload
 CREATE INDEX IF NOT EXISTS upload_content_cid_idx ON upload (content_cid);
 CREATE INDEX IF NOT EXISTS upload_source_cid_idx ON upload (source_cid);
 CREATE INDEX IF NOT EXISTS upload_updated_at_idx ON upload (updated_at);
+CREATE INDEX IF NOT EXISTS upload_type_idx ON upload (type);
 
 -- Metric contains the current values of collected metrics.
 CREATE TABLE IF NOT EXISTS metric


### PR DESCRIPTION
Crons for Pins and Metrics perform queries filtering out by columns of Pin and Upload table. We need to add indexes to these columns to boost performance.

TODO:
- [x] Add indexes to production once PR approved