### PR TITLE
Fix: Make the service fail early if environment variables are not defined.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ site/public
 
 public/sitemap.xml
 public/robots.txt
+.vscode/

--- a/packages/api/src/constants.js
+++ b/packages/api/src/constants.js
@@ -1,4 +1,36 @@
 // let MAGIC_SECRET_KEY, SALT, PINATA_JWT, SENTRY_DSN, DATABASE_TOKEN, CLUSTER_SERVICE, LOGTAIL_TOKEN, MAILCHIMP_API_KEY, METAPLEX_AUTH_TOKEN
+import { config } from 'dotenv'
+
+config({ debug: true })
+
+const {
+  MAGIC_SECRET_KEY,
+  SALT,
+  SENTRY_DSN,
+  DATABASE_TOKEN,
+  CLUSTER_SERVICE,
+  LOGTAIL_TOKEN,
+  MAILCHIMP_API_KEY,
+  CLUSTER_API_URL,
+  DATABASE_URL,
+  DEBUG,
+} = process.env
+
+if (!SALT) {
+  throw new Error('SALT is not defined')
+}
+
+if (!DATABASE_TOKEN) {
+  throw new Error('DATABASE_TOKEN is not defined')
+}
+
+if (!DATABASE_URL) {
+  throw new Error('DATABASE_URL is not defined')
+}
+
+if (!LOGTAIL_TOKEN) {
+  throw new Error('LOGTAIL_TOKEN is not defined')
+}
 
 export const secrets = {
   salt: SALT,
@@ -30,12 +62,17 @@ switch (CLUSTER_SERVICE) {
     break
 }
 
+if (!clusterUrl) {
+  throw new Error('CLUSTER_API_URL or CLUSTER_SERVICE must be set')
+}
+
+if (!CLUSTER_BASIC_AUTH_TOKEN) {
+  throw new Error('CLUSTER_BASIC_AUTH_TOKEN is not defined')
+}
+
 export const cluster = {
   apiUrl: clusterUrl,
-  basicAuthToken:
-    typeof CLUSTER_BASIC_AUTH_TOKEN !== 'undefined'
-      ? CLUSTER_BASIC_AUTH_TOKEN
-      : '',
+  basicAuthToken: CLUSTER_BASIC_AUTH_TOKEN || '',
   /**
    * When >2.5MB, use local add, because waiting for blocks to be sent to
    * other cluster nodes can take a long time. Replication to other nodes


### PR DESCRIPTION
Would anyone mind if we made the service explode if it doesn't have the environment variables it needs to run? 
This would make it easier to debug local dev, and give us some safeguard when deploying.