### PR TITLE
fix: gateway metrics track total winner successful requests

### DIFF
--- a/packages/gateway/src/durable-objects/generic-metrics.js
+++ b/packages/gateway/src/durable-objects/generic-metrics.js
@@ -1,10 +1,18 @@
+/**
+ * @typedef {Object} GenericMetrics
+ * @property {number} totalWinnerResponseTime total response time of the requests
+ * @property {number} totalWinnerSuccessfulRequests total number of successful requests
+ */
+
 // Key to track total time for winner gateway to respond
 const TOTAL_WINNER_RESPONSE_TIME_ID = 'totalWinnerResponseTime'
+// Key to track total successful requests
+const TOTAL_WINNER_SUCCESSFUL_REQUESTS_ID = 'totalWinnerSuccessfulRequests'
 
 /**
  * Durable Object for keeping generic Metrics of gateway.nft.storage
  */
-export class GenericMetrics0 {
+export class GenericMetrics1 {
   constructor(state) {
     this.state = state
 
@@ -13,6 +21,9 @@ export class GenericMetrics0 {
       // Total response time
       this.totalWinnerResponseTime =
         (await this.state.storage.get(TOTAL_WINNER_RESPONSE_TIME_ID)) || 0
+      // Total successful requests
+      this.totalWinnerSuccessfulRequests =
+        (await this.state.storage.get(TOTAL_WINNER_SUCCESSFUL_REQUESTS_ID)) || 0
     })
   }
 
@@ -25,14 +36,26 @@ export class GenericMetrics0 {
         const data = await request.json()
         // Updated Metrics
         this.totalWinnerResponseTime += data.responseTime
+        this.totalWinnerSuccessfulRequests += 1
         // Save updated Metrics
-        await this.state.storage.put(
-          TOTAL_WINNER_RESPONSE_TIME_ID,
-          this.totalWinnerResponseTime
-        )
+        await Promise.all([
+          this.state.storage.put(
+            TOTAL_WINNER_RESPONSE_TIME_ID,
+            this.totalWinnerResponseTime
+          ),
+          this.state.storage.put(
+            TOTAL_WINNER_SUCCESSFUL_REQUESTS_ID,
+            this.totalWinnerSuccessfulRequests
+          ),
+        ])
         return new Response()
       case '/metrics':
-        return new Response(this.totalWinnerResponseTime)
+        return new Response(
+          JSON.stringify({
+            totalWinnerResponseTime: this.totalWinnerResponseTime,
+            totalWinnerSuccessfulRequests: this.totalWinnerSuccessfulRequests,
+          })
+        )
       default:
         return new Response('Not found', { status: 404 })
     }

--- a/packages/gateway/src/index.js
+++ b/packages/gateway/src/index.js
@@ -7,7 +7,7 @@ import { metricsGet } from './metrics.js'
 
 // Export Durable Object namespace from the root module.
 export { GatewayMetrics0 } from './durable-objects/gateway-metrics.js'
-export { GenericMetrics0 } from './durable-objects/generic-metrics.js'
+export { GenericMetrics1 } from './durable-objects/generic-metrics.js'
 export { CidsTracker0 } from './durable-objects/cids.js'
 
 import { addCorsHeaders, withCorsHeaders } from './cors.js'

--- a/packages/gateway/test/metrics.spec.js
+++ b/packages/gateway/test/metrics.spec.js
@@ -17,7 +17,13 @@ test('Gets Metrics content when empty state', async (t) => {
   const metricsResponse = await response.text()
 
   t.is(
-    metricsResponse.includes('nftstorage_gateway_total_fastest_response_time'),
+    metricsResponse.includes('nftstorage_gateway_total_winner_response_time'),
+    true
+  )
+  t.is(
+    metricsResponse.includes(
+      'nftstorage_gateway_total_winner_successful_requests'
+    ),
     true
   )
   gateways.forEach((gw) => {

--- a/packages/gateway/test/utils.js
+++ b/packages/gateway/test/utils.js
@@ -14,7 +14,7 @@ export function getMiniflare() {
     modules: true,
     durableObjects: {
       GATEWAYMETRICS: 'GatewayMetrics0',
-      GENERICMETRICS: 'GenericMetrics0',
+      GENERICMETRICS: 'GenericMetrics1',
       CIDSTRACKER: 'CidsTracker0',
     },
   })

--- a/packages/gateway/wrangler.toml
+++ b/packages/gateway/wrangler.toml
@@ -122,3 +122,7 @@ deleted_classes = ["Metrics12"]
 tag = "v14" # Should be unique for each entry
 new_classes = ["GatewayMetrics0", "GenericMetrics0"]
 deleted_classes = ["Metrics13"]
+[[migrations]]
+tag = "v15" # Should be unique for each entry
+new_classes = ["GenericMetrics1"]
+deleted_classes = ["GenericMetrics0"]

--- a/packages/gateway/wrangler.toml
+++ b/packages/gateway/wrangler.toml
@@ -29,7 +29,7 @@ DEBUG = "false"
 ENV = "production"
 
 [env.production.durable_objects]
-bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"}, {name = "GENERICMETRICS", class_name = "GenericMetrics0"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
+bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"}, {name = "GENERICMETRICS", class_name = "GenericMetrics1"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
 
 # Staging!
 [env.staging]
@@ -44,7 +44,7 @@ DEBUG = "true"
 ENV = "staging"
 
 [env.staging.durable_objects]
-bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"}, {name = "GENERICMETRICS", class_name = "GenericMetrics0"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
+bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"}, {name = "GENERICMETRICS", class_name = "GenericMetrics1"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
 
 # Test!
 [env.test]
@@ -56,7 +56,7 @@ DEBUG = "true"
 ENV = "test"
 
 [env.test.durable_objects]
-bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"}, {name = "GENERICMETRICS", class_name = "GenericMetrics0"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
+bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"}, {name = "GENERICMETRICS", class_name = "GenericMetrics1"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
 
 # Dev!
 [env.vsantos]
@@ -67,7 +67,7 @@ account_id = "7ec0b7cf2ec201b2580374e53ba5f37b"
 IPFS_GATEWAYS = "[\"https://ipfs.io\"]"
 
 [env.vsantos.durable_objects]
-bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"}, {name = "GENERICMETRICS", class_name = "GenericMetrics0"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
+bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"}, {name = "GENERICMETRICS", class_name = "GenericMetrics1"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
 
 [[migrations]]
 tag = "v1" # Should be unique for each entry


### PR DESCRIPTION
For metrics that are not related to a specific IPFS public gateway, we were only tracking the sum of response times for the winner requests. However, we also need to track the total number of requests so that we can have proper visualisation of https://prometheus.io/docs/practices/histograms/#count-and-sum-of-observations