### PR TITLE
fix: gateway histogram metrics

### DIFF
--- a/packages/gateway/src/durable-objects/gateway-metrics.js
+++ b/packages/gateway/src/durable-objects/gateway-metrics.js
@@ -17,7 +17,7 @@ const GATEWAY_METRICS_ID = 'gateway_metrics'
 /**
  * Durable Object for keeping Metrics state of a gateway.
  */
-export class GatewayMetrics0 {
+export class GatewayMetrics1 {
   constructor(state) {
     this.state = state
 
@@ -74,15 +74,20 @@ export class GatewayMetrics0 {
       ...this.gatewayMetrics.responseTimeHistogram,
     }
 
-    const histogramCandidate =
-      histogram.find((h) => stats.responseTime <= h) ||
-      histogram[histogram.length - 1]
-    gwHistogram[histogramCandidate] += 1
+    // Get all the histogram buckets where the response time is smaller
+    const histogramCandidates = histogram.filter((h) => stats.responseTime < h)
+    histogramCandidates.forEach((candidate) => {
+      gwHistogram[candidate] += 1
+    })
+
     this.gatewayMetrics.responseTimeHistogram = gwHistogram
   }
 }
 
-export const histogram = [300, 500, 750, 1000, 1500, 2000, 3000, 5000, 10000]
+// We will count occurences per bucket where response time is less or equal than bucket value
+export const histogram = [
+  300, 500, 750, 1000, 1500, 2000, 3000, 5000, 10000, 20000,
+]
 
 function createMetricsTracker() {
   const h = histogram.map((h) => [h, 0])

--- a/packages/gateway/src/index.js
+++ b/packages/gateway/src/index.js
@@ -6,7 +6,7 @@ import { gatewayGet } from './gateway.js'
 import { metricsGet } from './metrics.js'
 
 // Export Durable Object namespace from the root module.
-export { GatewayMetrics0 } from './durable-objects/gateway-metrics.js'
+export { GatewayMetrics1 } from './durable-objects/gateway-metrics.js'
 export { GenericMetrics1 } from './durable-objects/generic-metrics.js'
 export { CidsTracker0 } from './durable-objects/cids.js'
 

--- a/packages/gateway/test/utils.js
+++ b/packages/gateway/test/utils.js
@@ -13,7 +13,7 @@ export function getMiniflare() {
     wranglerConfigEnv: 'test',
     modules: true,
     durableObjects: {
-      GATEWAYMETRICS: 'GatewayMetrics0',
+      GATEWAYMETRICS: 'GatewayMetrics1',
       GENERICMETRICS: 'GenericMetrics1',
       CIDSTRACKER: 'CidsTracker0',
     },

--- a/packages/gateway/wrangler.toml
+++ b/packages/gateway/wrangler.toml
@@ -29,7 +29,7 @@ DEBUG = "false"
 ENV = "production"
 
 [env.production.durable_objects]
-bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"}, {name = "GENERICMETRICS", class_name = "GenericMetrics1"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
+bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics1"}, {name = "GENERICMETRICS", class_name = "GenericMetrics1"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
 
 # Staging!
 [env.staging]
@@ -44,7 +44,7 @@ DEBUG = "true"
 ENV = "staging"
 
 [env.staging.durable_objects]
-bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"}, {name = "GENERICMETRICS", class_name = "GenericMetrics1"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
+bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics1"}, {name = "GENERICMETRICS", class_name = "GenericMetrics1"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
 
 # Test!
 [env.test]
@@ -56,7 +56,7 @@ DEBUG = "true"
 ENV = "test"
 
 [env.test.durable_objects]
-bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"}, {name = "GENERICMETRICS", class_name = "GenericMetrics1"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
+bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics1"}, {name = "GENERICMETRICS", class_name = "GenericMetrics1"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
 
 # Dev!
 [env.vsantos]
@@ -67,7 +67,7 @@ account_id = "7ec0b7cf2ec201b2580374e53ba5f37b"
 IPFS_GATEWAYS = "[\"https://ipfs.io\"]"
 
 [env.vsantos.durable_objects]
-bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"}, {name = "GENERICMETRICS", class_name = "GenericMetrics1"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
+bindings = [{name = "GATEWAYMETRICS", class_name = "GatewayMetrics1"}, {name = "GENERICMETRICS", class_name = "GenericMetrics1"}, {name = "CIDSTRACKER", class_name = "CidsTracker0"}]
 
 [[migrations]]
 tag = "v1" # Should be unique for each entry
@@ -126,3 +126,7 @@ deleted_classes = ["Metrics13"]
 tag = "v15" # Should be unique for each entry
 new_classes = ["GenericMetrics1"]
 deleted_classes = ["GenericMetrics0"]
+[[migrations]]
+tag = "v16" # Should be unique for each entry
+new_classes = ["GatewayMetrics1"]
+deleted_classes = ["GatewayMetrics0"]


### PR DESCRIPTION
This fixes histogram metrics, as they were being calculated in the opposite logic. We track metrics "le" https://ipfs-staging.nft.storage/metrics. For example, considering a response time of 1000ms, all the buckets bigger than 1000 should be incremented in order to track the counts of "less or equal" to the bucket and be able to properly compute metrics like 95th percentile.

More info:
- https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile
- https://www.robustperception.io/how-does-a-prometheus-histogram-work