### PR TITLE
fix: properly track errors on winner gateway fetch

### DIFF
--- a/packages/gateway/src/gateway.js
+++ b/packages/gateway/src/gateway.js
@@ -91,7 +91,7 @@ export async function gatewayGet(request, env, ctx) {
 async function storeWinnerGwResponse(request, env, winnerGwResponse) {
   await Promise.all([
     updateGatewayMetrics(request, env, winnerGwResponse, true),
-    updateGenericMetrics(request, env, winnerGwResponse),
+    updateSummaryMetrics(request, env, winnerGwResponse),
   ])
 }
 
@@ -140,7 +140,7 @@ async function _gatewayFetch(
  * @param {import('./env').Env} env
  * @param {GatewayResponse} gwResponse
  */
-async function updateGenericMetrics(request, env, gwResponse) {
+async function updateSummaryMetrics(request, env, gwResponse) {
   // Get durable object for gateway
   const id = env.genericMetricsDurable.idFromName(GENERIC_METRICS_ID)
   const stub = env.genericMetricsDurable.get(id)


### PR DESCRIPTION
We were not previously detecting in the winner request response if fetch response was successfully. This typically did not represent a problem because usually the errors would be timeouts. However, after trying a load test scenario in my local machine I noticed that `cf-ipfs.com` has rate limited enabled (don't know at this point what are the conditions of it, can't find documentation on this...).

So, when we hit the CF rate limit, every request was immediately responded with the Error, instead of waiting for further responses.

In this PR, I added a loop cycle where we wait until one request succeeds, properly tracking potential errors. A `GatewayResponsePromise` was created to track of the state of each promise and rely on `p-any` to wait for further results in a simple fashion.

As a follow up PR, I need to track potential rate limit errors and keep a state of that, in order to not try further requests to that gateway until it is back...  We need to discuss alternatives here, currently considering a new durable object but we would need a read before the gateway race.