### PR TITLE
fix: update size and alignment of cards while allowing height to expand

### DIFF
--- a/packages/website/components/blog/cards.js
+++ b/packages/website/components/blog/cards.js
@@ -16,17 +16,16 @@ import countly from '../../lib/countly'
 
 export const Card = ({ post }) => (
   <Link href={`/blog/post/${post.slug}`}>
-    <a className="bg-white blog-card h-card w-card hologram card right interactive pointer">
+    <a className="bg-white blog-card w-card hologram card right interactive pointer">
       <img
         src={post.thumbnail}
         alt={`Banner for ${post.title}`}
-        className="object-cover object-center w-100"
-        style={{ height: '50%' }}
+        className="object-cover object-center w-100 card-thumb"
       />
-      <div className="flex pa5 flex-column justify-evenly">
-        <div className="mb4">{post.tags && <Tags tags={post.tags} />}</div>
+      <div className="pa5 flex flex-column flex-auto">
+        <div className="mb2">{post.tags && <Tags tags={post.tags} />}</div>
         <div className="overflow-hidden mb2">
-          <h1 className="chicagoflf f3 line-clamp-1" title={post.title}>
+          <h1 className="chicagoflf f4" title={post.title}>
             {post.title}
           </h1>
         </div>
@@ -55,7 +54,7 @@ export const HighlightCard = ({ post }) => (
       <div className="flex justify-between highlight-info flex-column w-50">
         <div className="highlight-card-container">
           <div className="highlight-card-text">
-            <div className="mb4">{post.tags && <Tags tags={post.tags} />}</div>
+            <div className="mb3">{post.tags && <Tags tags={post.tags} />}</div>
             <h1
               className="chicagoflf f1 title"
               title={`Read More about"${post.title}"`}

--- a/packages/website/components/tags.js
+++ b/packages/website/components/tags.js
@@ -11,7 +11,9 @@ import clsx from 'clsx'
 export const Tag = ({ tag }) => {
   const isString = typeof tag === 'string'
   const inner = (
-    <span className={clsx('ph2 pv1 f6 ba ttc mr2', isString && 'select-none')}>
+    <span
+      className={clsx('ph2 pv1 f6 ba ttc mr1 mb1', isString && 'select-none')}
+    >
       {isString ? tag : tag.label}
     </span>
   )

--- a/packages/website/styles/blog.css
+++ b/packages/website/styles/blog.css
@@ -39,6 +39,19 @@ h6 {
   }
 }
 
+.card-thumb {
+  aspect-ratio: 16/9;
+}
+
+@supports not (aspect-ratio: auto) {
+  .card-thumb {
+    padding-top: 100%;
+    height: 0;
+    position: relative;
+    overflow: hidden;
+  }
+}
+
 .blog .w-card {
   width: var(--card-size);
 }
@@ -334,10 +347,6 @@ h6 {
 
   .blog-tags-buttons {
     justify-self: center;
-  }
-  .blog .button-tags-container {
-    padding-left: 1rem;
-    padding-right: 1rem;
   }
 }
 


### PR DESCRIPTION
addresses problem with #1158 for mobile container as well as preventing titles from being cut off all together on any device.
<img width="1678" alt="Screen Shot 2022-01-24 at 3 01 52 PM" src="https://user-images.githubusercontent.com/1189523/150880563-6130c76b-31b9-47e4-ae2f-15f1f2f8a4f2.png">
<img width="390" alt="Screen Shot 2022-01-24 at 3 13 06 PM" src="https://user-images.githubusercontent.com/1189523/150880667-a8bae8d9-305b-49cb-8e0f-1ad8bd406f39.png">

