### PR TITLE
fix: gateway metrics for prometheus histogram requires upper bound +inf

### DIFF
--- a/packages/gateway/src/metrics.js
+++ b/packages/gateway/src/metrics.js
@@ -119,6 +119,10 @@ export async function metricsGet(request, env, ctx) {
         )
         .join('\n')
     }),
+    ...env.ipfsGateways.map(
+      (gw) =>
+        `nftstorage_gateway_requests_per_time{gateway="${gw}",le="+Inf",env="${env.ENV}"} ${metricsCollected.ipfsGateways[gw].totalSuccessfulRequests}`
+    ),
   ].join('\n')
 
   res = new Response(metrics, {


### PR DESCRIPTION
For properly visualising in Grafana an Histogram Quantile we need an upper bound +inf with the total number of successful requests per https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile