### PR TITLE
Fix: issue 1152 cid truncation

### DIFF
--- a/packages/website/components/copyButton.js
+++ b/packages/website/components/copyButton.js
@@ -45,7 +45,7 @@ function CopyButton({ text, title, popupContent, children, ...props }) {
       <button
         onClick={handleCopy}
         title={title}
-        className="icon-button transparent v-mid mr2"
+        className="icon-button transparent v-mid"
         {...props}
       >
         <span

--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -196,7 +196,14 @@ export default function Files({ user }) {
             text={nft.cid}
             popupContent={'CID has been copied!!'}
           >
-            <p className="dib black">{nft.cid}</p>
+            <a
+              href={`https://ipfs.io/ipfs/${nft.cid}`}
+              className="underline black truncate"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {nft.cid}
+            </a>
           </CopyButton>
           <GatewayLink cid={nft.cid} type={nft.type} />
         </td>

--- a/packages/website/styles/table.css
+++ b/packages/website/styles/table.css
@@ -72,6 +72,19 @@
   justify-content: flex-end;
 }
 
+@media screen and (max-width: 52em) {
+  .table-responsive table tr td.nowrap {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .table-responsive table tr td.nowrap .truncate {
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+}
+
 /* 832px */
 @media screen and (min-width: 52em) {
   /*Additive styles at full size*/

--- a/packages/website/styles/table.css
+++ b/packages/website/styles/table.css
@@ -83,6 +83,25 @@
     text-overflow: ellipsis;
     overflow: hidden;
   }
+  .table-responsive table tr td.nowrap .truncate + .icon-button {
+    padding-right: 0;
+  }
+
+  .table-responsive table tr td.nowrap .popup.active::after {
+    height: 12px;
+    left: inherit;
+    right: 10px;
+    top: -4px;
+    display: flex;
+    align-items: center;
+    border: 1px solid;
+    margin-left: 0;
+    animation: none;
+    width: auto;
+    font-size: 0.9rem !important;
+    padding: 5px 15px;
+    transform: none;
+  }
 }
 
 /* 832px */


### PR DESCRIPTION
<img width="540" alt="Screen Shot 2022-01-28 at 8 49 47 AM" src="https://user-images.githubusercontent.com/1189523/151592838-313feef2-6ca0-40cd-93e3-101013ab6ab5.png">
Using flexbox we can have the width get inherited so that it fits as much as it can before truncating the cid.

also updates the popover to prevent it from getting cutoff
<img width="519" alt="Screen Shot 2022-01-28 at 9 14 03 AM" src="https://user-images.githubusercontent.com/1189523/151592894-e3652fe4-16cf-414f-b55f-345fa0f00834.png">

