### PR TITLE
fix: gateway prometheus metrics best practices naming

### DIFF
--- a/packages/gateway/src/metrics.js
+++ b/packages/gateway/src/metrics.js
@@ -68,9 +68,9 @@ export async function metricsGet(request, env, ctx) {
   }
 
   const metrics = [
-    `# HELP nftstorage_gateway_total_cache_hit_responses Total cached responses returned.`,
-    `# TYPE nftstorage_gateway_total_cache_hit_responses counter`,
-    `nftstorage_gateway_total_cache_hit_responses{env="${env.ENV}"} ${metricsCollected.summaryMetrics.totalCachedResponses}`,
+    `# HELP nftgateway_cache_hit_responses_total Total cached responses returned.`,
+    `# TYPE nftgateway_cache_hit_responses_total counter`,
+    `nftgateway_cache_hit_responses_total{env="${env.ENV}"} ${metricsCollected.summaryMetrics.totalCachedResponses}`,
     `# HELP nftgateway_winner_requests_total Total winner requests.`,
     `# TYPE nftgateway_winner_requests_total counter`,
     `nftgateway_winner_requests_total{env="${env.ENV}"} ${metricsCollected.summaryMetrics.totalWinnerSuccessfulRequests}`,

--- a/packages/gateway/src/metrics.js
+++ b/packages/gateway/src/metrics.js
@@ -68,63 +68,65 @@ export async function metricsGet(request, env, ctx) {
   }
 
   const metrics = [
-    `# HELP nftstorage_gateway_total_cached_responses Total cached responses returned.`,
-    `# TYPE nftstorage_gateway_total_cached_responses counter`,
-    `nftstorage_gateway_total_cached_responses{env="${env.ENV}"} ${metricsCollected.summaryMetrics.totalCachedResponses}`,
-    `# HELP nftstorage_gateway_total_winner_response_time Total requests performed.`,
-    `# TYPE nftstorage_gateway_total_winner_response_time counter`,
-    `nftstorage_gateway_total_winner_response_time{env="${env.ENV}"} ${metricsCollected.summaryMetrics.totalWinnerResponseTime}`,
-    `# HELP nftstorage_gateway_total_winner_successful_requests Total successful requests.`,
-    `# TYPE nftstorage_gateway_total_winner_successful_requests counter`,
-    `nftstorage_gateway_total_winner_successful_requests{env="${env.ENV}"} ${metricsCollected.summaryMetrics.totalWinnerSuccessfulRequests}`,
-    `# HELP nftstorage_gateway_total_response_time Average response time.`,
-    `# TYPE nftstorage_gateway_total_response_time gauge`,
+    `# HELP nftstorage_gateway_total_cache_hit_responses Total cached responses returned.`,
+    `# TYPE nftstorage_gateway_total_cache_hit_responses counter`,
+    `nftstorage_gateway_total_cache_hit_responses{env="${env.ENV}"} ${metricsCollected.summaryMetrics.totalCachedResponses}`,
+    `# HELP nftgateway_winner_requests_total Total winner requests.`,
+    `# TYPE nftgateway_winner_requests_total counter`,
+    `nftgateway_winner_requests_total{env="${env.ENV}"} ${metricsCollected.summaryMetrics.totalWinnerSuccessfulRequests}`,
+    `# HELP nftgateway_winner_response_time_seconds_total Accumulated winner response time.`,
+    `# TYPE nftgateway_winner_response_time_seconds_total summary`,
+    `nftgateway_winner_response_time_seconds_total{env="${env.ENV}"} ${msToS(
+      metricsCollected.summaryMetrics.totalWinnerResponseTime
+    )}`,
+    `# HELP nftgateway_response_time_seconds_total Accumulated response time of each gateway.`,
+    `# TYPE nftgateway_response_time_seconds_total summary`,
     ...env.ipfsGateways.map(
       (gw) =>
-        `nftstorage_gateway_total_response_time{gateway="${gw}",env="${
+        `nftgateway_response_time_seconds_total{gateway="${gw}",env="${
           env.ENV
-        }"} ${metricsCollected.ipfsGateways[gw].totalResponseTime || 0}`
+        }"} ${msToS(metricsCollected.ipfsGateways[gw].totalResponseTime) || 0}`
     ),
-    `# HELP nftstorage_gateway_total_requests Total requests performed.`,
-    `# TYPE nftstorage_gateway_total_requests counter`,
+    `# HELP nftgateway_requests_total Total requests performed to each gateway.`,
+    `# TYPE nftgateway_requests_total counter`,
     ...env.ipfsGateways.map(
       (gw) =>
-        `nftstorage_gateway_total_requests{gateway="${gw}",env="${env.ENV}"} ${
+        `nftgateway_requests_total{gateway="${gw}",env="${env.ENV}"} ${
           metricsCollected.ipfsGateways[gw].totalSuccessfulRequests +
           metricsCollected.ipfsGateways[gw].totalFailedRequests
         }`
     ),
-    `# HELP nftstorage_gateway_total_successful_requests Total successful requests.`,
-    `# TYPE nftstorage_gateway_total_successful_requests counter`,
+    `# HELP nftgateway_successful_requests_total Total successful requests performed to each gateway.`,
+    `# TYPE nftgateway_successful_requests_total counter`,
     ...env.ipfsGateways.map(
       (gw) =>
-        `nftstorage_gateway_total_successful_requests{gateway="${gw}",env="${env.ENV}"} ${metricsCollected.ipfsGateways[gw].totalSuccessfulRequests}`
+        `nftgateway_successful_requests_total{gateway="${gw}",env="${env.ENV}"} ${metricsCollected.ipfsGateways[gw].totalSuccessfulRequests}`
     ),
-    `# HELP nftstorage_gateway_total_failed_requests Total failed requests.`,
-    `# TYPE nftstorage_gateway_total_failed_requests counter`,
+    `# HELP nftgateway_failed_requests_total Total failed requests performed to each gateway.`,
+    `# TYPE nftgateway_failed_requests_total counter`,
     ...env.ipfsGateways.map(
       (gw) =>
-        `nftstorage_gateway_total_failed_requests{gateway="${gw}",env="${env.ENV}"} ${metricsCollected.ipfsGateways[gw].totalFailedRequests}`
+        `nftgateway_failed_requests_total{gateway="${gw}",env="${env.ENV}"} ${metricsCollected.ipfsGateways[gw].totalFailedRequests}`
     ),
-    `# HELP nftstorage_gateway_total_faster_requests Total requests with faster response.`,
-    `# TYPE nftstorage_gateway_total_faster_requests counter`,
+    `# HELP nftgateway_winner_requests_total Total requests with winner response to each gateway.`,
+    `# TYPE nftgateway_winner_requests_total counter`,
     ...env.ipfsGateways.map(
       (gw) =>
-        `nftstorage_gateway_total_faster_requests{gateway="${gw}",env="${env.ENV}"} ${metricsCollected.ipfsGateways[gw].totalWinnerRequests}`
+        `nftgateway_winner_requests_total{gateway="${gw}",env="${env.ENV}"} ${metricsCollected.ipfsGateways[gw].totalWinnerRequests}`
     ),
-    `# HELP nftstorage_gateway_requests_per_time`,
-    `# TYPE nftstorage_gateway_requests_per_time histogram`,
+    `# HELP nftgateway_requests_per_time_total`,
+    `# TYPE nftgateway_requests_per_time_total histogram for total of requests per response time bucket`,
     ...histogram.map((t) => {
       return env.ipfsGateways
         .map(
           (gw) =>
-            `nftstorage_gateway_requests_per_time{gateway="${gw}",le="${t}",env="${env.ENV}"} ${metricsCollected.ipfsGateways[gw].responseTimeHistogram[t]}`
+            `nftgateway_requests_per_time_total{gateway="${gw}",le="${t}",env="${env.ENV}"} ${metricsCollected.ipfsGateways[gw].responseTimeHistogram[t]}`
         )
         .join('\n')
     }),
     ...env.ipfsGateways.map(
       (gw) =>
-        `nftstorage_gateway_requests_per_time{gateway="${gw}",le="+Inf",env="${env.ENV}"} ${metricsCollected.ipfsGateways[gw].totalSuccessfulRequests}`
+        `nftgateway_requests_per_time_total{gateway="${gw}",le="+Inf",env="${env.ENV}"} ${metricsCollected.ipfsGateways[gw].totalSuccessfulRequests}`
     ),
   ].join('\n')
 
@@ -137,4 +139,12 @@ export async function metricsGet(request, env, ctx) {
   // ctx.waitUntil(cache.put(request, res.clone()))
 
   return res
+}
+
+/**
+ * Convert milliseconds to seconds.
+ * @param {number} ms
+ */
+function msToS(ms) {
+  return ms / 1000
 }

--- a/packages/gateway/test/metrics.spec.js
+++ b/packages/gateway/test/metrics.spec.js
@@ -17,40 +17,35 @@ test('Gets Metrics content when empty state', async (t) => {
   const metricsResponse = await response.text()
 
   t.is(
-    metricsResponse.includes('nftstorage_gateway_total_winner_response_time'),
+    metricsResponse.includes('nftgateway_winner_response_time_seconds_total'),
     true
   )
-  t.is(
-    metricsResponse.includes(
-      'nftstorage_gateway_total_winner_successful_requests'
-    ),
-    true
-  )
+  t.is(metricsResponse.includes('nftgateway_winner_requests_total'), true)
   gateways.forEach((gw) => {
     t.is(
-      metricsResponse.includes(`_total_requests{gateway="${gw}",env="test"} 0`),
+      metricsResponse.includes(`_requests_total{gateway="${gw}",env="test"} 0`),
       true
     )
     t.is(
       metricsResponse.includes(
-        `_total_response_time{gateway="${gw}",env="test"}`
+        `_response_time_seconds_total{gateway="${gw}",env="test"}`
       ),
       true
     )
     t.is(
       metricsResponse.includes(
-        `_total_failed_requests{gateway="${gw}",env="test"} 0`
+        `_failed_requests_total{gateway="${gw}",env="test"} 0`
       ),
       true
     )
     t.is(
       metricsResponse.includes(
-        `_total_faster_requests{gateway="${gw}",env="test"} 0`
+        `_winner_requests_total{gateway="${gw}",env="test"} 0`
       ),
       true
     )
     t.is(
-      metricsResponse.includes(`_requests_per_time{gateway="${gw}",le=`),
+      metricsResponse.includes(`requests_per_time_total{gateway="${gw}",le=`),
       true
     )
   })
@@ -77,7 +72,7 @@ test('Gets Metrics content', async (t) => {
 
   gateways.forEach((gw) => {
     t.is(
-      metricsResponse.includes(`_total_requests{gateway="${gw}",env="test"} 2`),
+      metricsResponse.includes(`_requests_total{gateway="${gw}",env="test"} 2`),
       true
     )
   })
@@ -104,7 +99,7 @@ test('Gets Metrics from faster gateway', async (t) => {
 
   gateways.forEach((gw) => {
     t.is(
-      metricsResponse.includes(`_total_requests{gateway="${gw}",env="test"} 2`),
+      metricsResponse.includes(`_requests_total{gateway="${gw}",env="test"} 2`),
       true
     )
   })
@@ -112,7 +107,7 @@ test('Gets Metrics from faster gateway', async (t) => {
   // gateways[0] or gateways[1] are always faster
   t.is(
     metricsResponse.includes(
-      `_total_faster_requests{gateway="${gateways[2]}",env="test"} 0`
+      `_winner_requests_total{gateway="${gateways[2]}",env="test"} 0`
     ),
     true
   )
@@ -139,13 +134,13 @@ test('Counts failures', async (t) => {
 
   t.is(
     metricsResponse.includes(
-      `_total_requests{gateway="${gateways[2]}",env="test"} 2`
+      `_requests_total{gateway="${gateways[2]}",env="test"} 2`
     ),
     true
   )
   t.is(
     metricsResponse.includes(
-      `_total_failed_requests{gateway="${gateways[2]}",env="test"} 2`
+      `_failed_requests_total{gateway="${gateways[2]}",env="test"} 2`
     ),
     true
   )


### PR DESCRIPTION
This PR fixes prometheus metrics naming per best practices and conventions defined in https://prometheus.io/docs/practices/naming/ . Thanks @alanshaw for the pointer ❤️ 

In summary, the changes are:
- A metric name should have a (single-word) application prefix relevant to the domain the metric belongs to => made it nftgateway instead of previous two words
- A metric name should use base units => milliseconds converted to seconds
- A metric name should have a suffix describing the unit, in plural form (or total for a unit-less accumulating count) => all "total" are now suffixes and unit applied where applicable (response time seconds)

Closes https://github.com/nftstorage/nft.storage/issues/1182