### PR TITLE
fix: only cache when content length smaller than max object size

### DIFF
--- a/packages/gateway/src/constants.js
+++ b/packages/gateway/src/constants.js
@@ -1,3 +1,4 @@
+export const CLOUDFLARE_MAX_OBJECT_SIZE = 512 * Math.pow(1024, 2) // 512MB to bytes
 export const METRICS_CACHE_MAX_AGE = 10 * 60 // in seconds (10 minutes)
 export const CIDS_TRACKER_ID = 'cids'
 export const SUMMARY_METRICS_ID = 'summary-metrics'

--- a/packages/gateway/src/constants.js
+++ b/packages/gateway/src/constants.js
@@ -1,4 +1,4 @@
-export const CLOUDFLARE_MAX_OBJECT_SIZE = 512 * Math.pow(1024, 2) // 512MB to bytes
+export const CF_CACHE_MAX_OBJECT_SIZE = 512 * Math.pow(1024, 2) // 512MB to bytes
 export const METRICS_CACHE_MAX_AGE = 10 * 60 // in seconds (10 minutes)
 export const CIDS_TRACKER_ID = 'cids'
 export const SUMMARY_METRICS_ID = 'summary-metrics'

--- a/packages/gateway/src/gateway.js
+++ b/packages/gateway/src/gateway.js
@@ -8,7 +8,7 @@ import { getCidFromSubdomainUrl } from './utils/cid.js'
 import {
   CIDS_TRACKER_ID,
   SUMMARY_METRICS_ID,
-  CLOUDFLARE_MAX_OBJECT_SIZE,
+  CF_CACHE_MAX_OBJECT_SIZE,
 } from './constants.js'
 
 /**
@@ -76,8 +76,8 @@ export async function gatewayGet(request, env, ctx) {
         await Promise.all([
           storeWinnerGwResponse(request, env, winnerGwResponse),
           settleGatewayRequests(),
-          // Cache request URL in Cloudflare CDN if smaller than CLOUDFLARE_MAX_OBJECT_SIZE
-          contentLengthMb < CLOUDFLARE_MAX_OBJECT_SIZE &&
+          // Cache request URL in Cloudflare CDN if smaller than CF_CACHE_MAX_OBJECT_SIZE
+          contentLengthMb <= CF_CACHE_MAX_OBJECT_SIZE &&
             cache.put(request.url, winnerGwResponse.response.clone()),
         ])
       })()

--- a/packages/gateway/src/gateway.js
+++ b/packages/gateway/src/gateway.js
@@ -5,7 +5,11 @@ import pAny from 'p-any'
 import pSettle from 'p-settle'
 
 import { getCidFromSubdomainUrl } from './utils/cid.js'
-import { CIDS_TRACKER_ID, SUMMARY_METRICS_ID } from './constants.js'
+import {
+  CIDS_TRACKER_ID,
+  SUMMARY_METRICS_ID,
+  CLOUDFLARE_MAX_OBJECT_SIZE,
+} from './constants.js'
 
 /**
  * @typedef {Object} GatewayResponse
@@ -65,11 +69,16 @@ export async function gatewayGet(request, env, ctx) {
 
     ctx.waitUntil(
       (async () => {
+        const contentLengthMb = Number(
+          winnerGwResponse.response.headers.get('content-length')
+        )
+
         await Promise.all([
           storeWinnerGwResponse(request, env, winnerGwResponse),
           settleGatewayRequests(),
-          // Cache request URL in Cloudflare CDN
-          cache.put(request.url, winnerGwResponse.response.clone()),
+          // Cache request URL in Cloudflare CDN if smaller than CLOUDFLARE_MAX_OBJECT_SIZE
+          contentLengthMb < CLOUDFLARE_MAX_OBJECT_SIZE &&
+            cache.put(request.url, winnerGwResponse.response.clone()),
         ])
       })()
     )


### PR DESCRIPTION
Part of https://github.com/nftstorage/nft.storage/issues/1181 implemented. Only cache when content smaller than max object size limit https://developers.cloudflare.com/workers/platform/limits#cache-api-limits

Will track metrics in follow up PR