### PR TITLE
fix: client close blockstore on store directory and store blob

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -49,7 +49,7 @@
     "@ipld/car": "^3.1.20",
     "@ipld/dag-cbor": "^6.0.13",
     "@web-std/blob": "^3.0.1",
-    "@web-std/fetch": "^3.0.0",
+    "@web-std/fetch": "^3.0.3",
     "@web-std/file": "^3.0.0",
     "@web-std/form-data": "^3.0.0",
     "carbites": "^1.0.6",

--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -34,6 +34,7 @@ const MAX_CHUNK_SIZE = 1024 * 1024 * 10 // chunk to ~10MB CARs
  * @typedef {import('./lib/interface.js').Deal} Deal
  * @typedef {import('./lib/interface.js').Pin} Pin
  * @typedef {import('./lib/interface.js').CarReader} CarReader
+ * @typedef {import('ipfs-car/blockstore').Blockstore} BlockstoreI
  */
 
 /**
@@ -99,9 +100,18 @@ class NFTStorage {
    * @returns {Promise<CIDString>}
    */
   static async storeBlob(service, blob) {
-    const { cid, car } = await NFTStorage.encodeBlob(blob)
-    await NFTStorage.storeCar(service, car)
-    return cid.toString()
+    const blockstore = new Blockstore()
+    let cidString
+
+    try {
+      const { cid, car } = await NFTStorage.encodeBlob(blob, blockstore)
+      await NFTStorage.storeCar(service, car)
+      cidString = cid.toString()
+    } finally {
+      await blockstore.close()
+    }
+
+    return cidString
   }
 
   /**
@@ -177,9 +187,18 @@ class NFTStorage {
    * @returns {Promise<CIDString>}
    */
   static async storeDirectory(service, files) {
-    const { cid, car } = await NFTStorage.encodeDirectory(files)
-    await NFTStorage.storeCar(service, car)
-    return cid.toString()
+    const blockstore = new Blockstore()
+    let cidString
+
+    try {
+      const { cid, car } = await NFTStorage.encodeDirectory(files, blockstore)
+      await NFTStorage.storeCar(service, car)
+      cidString = cid.toString()
+    } finally {
+      await blockstore.close()
+    }
+
+    return cidString
   }
 
   /**
@@ -347,14 +366,18 @@ class NFTStorage {
    * ```
    *
    * @param {Blob} blob
+   * @param {BlockstoreI} blockstore
    * @returns {Promise<{ cid: CID, car: CarReader }>}
    */
-  static async encodeBlob(blob) {
+  static async encodeBlob(blob, blockstore) {
     if (blob.size === 0) {
       throw new Error('Content size is 0, make sure to provide some content')
     }
-
-    return packCar([{ path: 'blob', content: blob.stream() }], false)
+    return packCar(
+      [{ path: 'blob', content: blob.stream() }],
+      blockstore,
+      false
+    )
   }
 
   /**
@@ -378,9 +401,10 @@ class NFTStorage {
    * ```
    *
    * @param {Iterable<File>} files
+   * @param {BlockstoreI} blockstore
    * @returns {Promise<{ cid: CID, car: CarReader }>}
    */
-  static async encodeDirectory(files) {
+  static async encodeDirectory(files, blockstore) {
     const input = []
     let size = 0
     for (const file of files) {
@@ -394,7 +418,7 @@ class NFTStorage {
       )
     }
 
-    return packCar(input, true)
+    return packCar(input, blockstore, true)
   }
 
   // Just a sugar so you don't have to pass around endpoint and token around.
@@ -604,10 +628,10 @@ For more context please see ERC-721 specification https://eips.ethereum.org/EIPS
 
 /**
  * @param {Array<{ path: string, content: import('./platform.js').ReadableStream }>} input
+ * @param {BlockstoreI} blockstore
  * @param {boolean} wrapWithDirectory
  */
-const packCar = async (input, wrapWithDirectory) => {
-  const blockstore = new Blockstore()
+const packCar = async (input, blockstore, wrapWithDirectory) => {
   const { root: cid } = await pack({ input, blockstore, wrapWithDirectory })
   const car = new BlockstoreCarReader(1, [cid], blockstore)
   return { cid, car }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4055,6 +4055,16 @@
     "@web3-storage/multipart-parser" "^1.0.0"
     data-uri-to-buffer "^3.0.1"
 
+"@web-std/fetch@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@web-std/fetch/-/fetch-3.0.3.tgz#507e1371825298aae61172b0da439570437d3982"
+  integrity sha512-PtaKr6qvw2AmKChugzhQWuTa12dpbogHRBxwcleAZ35UhWucnfD4N+g3f7qYK2OeioSWTK3yMf6n/kOOfqxHaQ==
+  dependencies:
+    "@web-std/blob" "^3.0.3"
+    "@web-std/form-data" "^3.0.2"
+    "@web3-storage/multipart-parser" "^1.0.0"
+    data-uri-to-buffer "^3.0.1"
+
 "@web-std/file-url@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@web-std/file-url/-/file-url-1.0.1.tgz#41209ec581ee7c97b19222b5daf47f2992f6fdd8"


### PR DESCRIPTION
Given we use a CarReader now, we can only close the blockstore once pack is finished.

Also updated @web-std/fetch to avoid `Error: Cannot find module '/home/runner/work/nft.storage/nft.storage/node_modules/@web-std/fetch/dist/index.cjs'`

Closes https://github.com/nftstorage/nft.storage/issues/1186