### PR TITLE
fix: add durable object types

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,7 +33,7 @@
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^3.1.1",
+    "@cloudflare/workers-types": "^3.3.1",
     "@sentry/cli": "^1.71.0",
     "@sentry/webpack-plugin": "^1.16.0",
     "@types/debug": "^4.1.5",

--- a/packages/gateway/src/env.js
+++ b/packages/gateway/src/env.js
@@ -2,7 +2,6 @@ import Toucan from 'toucan-js'
 import pkg from '../package.json'
 import { Logging } from './logs.js'
 
-// TODO: Get Durable object typedef
 /**
  * @typedef {Object} EnvInput
  * @property {string} IPFS_GATEWAYS
@@ -22,11 +21,12 @@ import { Logging } from './logs.js'
  *
  * @typedef {Object} EnvTransformed
  * @property {Array<string>} ipfsGateways
- * @property {Object} gatewayMetricsDurable
- * @property {Object} summaryMetricsDurable
- * @property {Object} cidsTrackerDurable
- * @property {Object} gatewayRateLimitsDurable
- * @property {Object} gatewayRedirectCounter
+ * @property {DurableObjectNamespace} gatewayMetricsDurable
+ * @property {DurableObjectNamespace} summaryMetricsDurable
+ * @property {DurableObjectNamespace} cidsTrackerDurable
+ * @property {DurableObjectNamespace} gatewayRateLimitsDurable
+ * @property {DurableObjectNamespace} gatewayRedirectCounter
+ * @property {number} REQUEST_TIMEOUT
  * @property {Toucan} [sentry]
  * @property {Logging} [log]
  *
@@ -77,3 +77,26 @@ function getSentry(request, env) {
     pkg,
   })
 }
+
+/**
+ * From: https://github.com/cloudflare/workers-types
+ *
+ * @typedef {{
+ *  toString(): string
+ *  equals(other: DurableObjectId): boolean
+ *  readonly name?: string
+ * }} DurableObjectId
+ *
+ * @typedef {{
+ *   newUniqueId(options?: { jurisdiction?: string }): DurableObjectId
+ *   idFromName(name: string): DurableObjectId
+ *   idFromString(id: string): DurableObjectId
+ *   get(id: DurableObjectId): DurableObjectStub
+ * }} DurableObjectNamespace
+ *
+ * @typedef {{
+ *   readonly id: DurableObjectId
+ *   readonly name?: string
+ *   fetch(requestOrUrl: Request | string, requestInit?: RequestInit | Request): Promise<Response>
+ * }} DurableObjectStub
+ */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1057,10 +1057,10 @@
   resolved "https://registry.yarnpkg.com/@cfworker/json-schema/-/json-schema-1.12.1.tgz#8b151da771678d37bf77c5eda87b1137b2b009c8"
   integrity sha512-ZVhk1DKw19sBJgO7OHBsvNAzDfHMzpFI0DCkOLTZHb0dccmS+EM8rwwAYh5eaNmD5t8/nCbZ2ZeGzbDQdOzokQ==
 
-"@cloudflare/workers-types@^3.1.1":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.4.0.tgz#80311e14df2f7f8c2cfcdce945b4f4ad8f9b03b1"
-  integrity sha512-i/3czUrt6YqbOWl44OtIqd0cSZvEVXp/1oD/DZylC4PHZL3q/BhbamdEVeVhc/HPk4iD/7MZ2HGaIMO4Z4b12A==
+"@cloudflare/workers-types@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.3.1.tgz#8847543bda320472252708c29aaf7bac3374e814"
+  integrity sha512-GJFDgWd8ZHlr/m+Q2mp4xUl0/FIPpR6kf0Ix2C78E9HeJyUCW0c0w2EKCvgEDFFKB2rkzIX3eBqZCnLsbsw8zQ==
 
 "@concordance/react@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
Adds Cloudflare Durable object types inline and the `@cloudflare/workers-types` dev dependency. The Durable objects types are not exported from `@cloudflare/workers-types`