### PR TITLE
fix: update tooltip styles to match site

### DIFF
--- a/packages/website/components/tooltip.js
+++ b/packages/website/components/tooltip.js
@@ -22,7 +22,7 @@ const Tooltip = ({
   <RCTooltip
     placement={placement}
     overlay={<div className="bg-white p2 f6 flex">{overlay}</div>}
-    overlayInnerStyle={{ borderColor: '#ee4116' }}
+    overlayInnerStyle={{ borderColor: '#000' }}
     destroyTooltipOnHide={destroyTooltipOnHide}
     overlayClassName={overlayClassName}
     id={id}

--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -156,7 +156,7 @@ export default function Files({ user }) {
             overlayClassName="table-tooltip"
             id="queued-deals-tooltip"
           >
-            <VscQuestion size={16} className="ml2" />
+            <VscQuestion size={16} />
           </Tooltip>
         </span>
       )
@@ -181,7 +181,7 @@ export default function Files({ user }) {
             overlayClassName="table-tooltip"
             id="all-deals-queued-tooltip"
           >
-            <VscQuestion size={16} className="ml2 flex self-end" />
+            <VscQuestion size={16} className="flex self-end" />
           </Tooltip>
         </span>
       )

--- a/packages/website/styles/table.css
+++ b/packages/website/styles/table.css
@@ -198,10 +198,22 @@
   border: 1px solid #000;
   padding: 6px 10px;
   cursor: pointer;
+  color: #000;
 }
 
 .actions-trigger:focus,
 .actions-trigger--active {
   background-color: #000;
   color: #fff;
+}
+
+.rc-tooltip.table-tooltip {
+  opacity: 1;
+  max-width: 40ch;
+}
+
+.rc-tooltip.table-tooltip .rc-tooltip-content {
+  border-radius: 0;
+  border: 1px solid #000;
+  font-family: var(--sansserif);
 }


### PR DESCRIPTION
... should also addresses ios safari 'actions' button color.
New tooltip looks like this:
<img width="419" alt="Screen Shot 2022-02-02 at 12 58 24 PM" src="https://user-images.githubusercontent.com/1189523/152237310-a712d35d-8e32-435c-aaaa-7e8d078b179c.png">

