### PR TITLE
feat: gateway with x-forwarded-for ip for ipfs.io gateway

### DIFF
--- a/packages/gateway/src/gateway.js
+++ b/packages/gateway/src/gateway.js
@@ -173,7 +173,7 @@ async function gatewayFetch(
   try {
     response = await fetch(`${ipfsUrl.toString()}/${cid}${pathname}`, {
       signal: controller.signal,
-      headers: _getHeadersForGateway(gwUrl, request),
+      headers: getHeaders(request),
     })
   } finally {
     clearTimeout(timer)
@@ -189,14 +189,9 @@ async function gatewayFetch(
 }
 
 /**
- * @param {string} gwUrl
  * @param {Request} request
  */
-function _getHeadersForGateway(gwUrl, request) {
-  if (gwUrl !== 'https://ipfs.io') {
-    return {}
-  }
-
+function getHeaders(request) {
   const existingProxies = request.headers['X-Forwarded-For']
     ? `, ${request.headers['X-Forwarded-For']}`
     : ''

--- a/packages/gateway/src/gateway.js
+++ b/packages/gateway/src/gateway.js
@@ -197,8 +197,11 @@ function _getHeadersForGateway(gwUrl, request) {
     return {}
   }
 
+  const existingProxies = request.headers['X-Forwarded-For']
+    ? `, ${request.headers['X-Forwarded-For']}`
+    : ''
   return {
-    'X-Forwarded-For': request.headers['cf-connecting-ip'],
+    'X-Forwarded-For': `${request.headers['cf-connecting-ip']}${existingProxies}`,
   }
 }
 

--- a/packages/gateway/src/gateway.js
+++ b/packages/gateway/src/gateway.js
@@ -173,6 +173,7 @@ async function gatewayFetch(
   try {
     response = await fetch(`${ipfsUrl.toString()}/${cid}${pathname}`, {
       signal: controller.signal,
+      headers: _getHeadersForGateway(gwUrl, request),
     })
   } finally {
     clearTimeout(timer)
@@ -185,6 +186,20 @@ async function gatewayFetch(
     responseTime: Date.now() - startTs,
   }
   return gwResponse
+}
+
+/**
+ * @param {string} gwUrl
+ * @param {Request} request
+ */
+function _getHeadersForGateway(gwUrl, request) {
+  if (gwUrl !== 'https://ipfs.io') {
+    return {}
+  }
+
+  return {
+    'X-Forwarded-For': request.headers['cf-connecting-ip'],
+  }
 }
 
 /**
@@ -203,7 +218,7 @@ async function updateSummaryCacheMetrics(request, env, response) {
   }
 
   await stub.fetch(
-    _getDurableRequestUrl(request, 'metrics/cache', contentLengthStats)
+    getDurableRequestUrl(request, 'metrics/cache', contentLengthStats)
   )
 }
 


### PR DESCRIPTION
This PR adds [`x-forwarded-for`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) IP from client to work around rate limiting from ipfs.io gateway. As part of support in https://github.com/protocol/bifrost-infra/issues/1609

The client IP is obtained from https://developers.cloudflare.com/workers/runtime-apis/headers#request-headers

I made this specific to the ipfs.io gateway to make clear that only it has support for this, but we could also just send it in all of them.

Tested by creating a route where response is just the headers of request in staging and confirmed it has my public IP.

![image](https://user-images.githubusercontent.com/7295071/152313230-5547741c-00b1-4c0a-abdc-c8403f6489a3.png)