### PR TITLE
fix: add pre-bundled esm build to package exports

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,6 +27,11 @@
       "browser": "./src/token.js",
       "require": "./dist/src/token.cjs",
       "node": "./src/token.js"
+    },
+    "./dist/bundle.esm.min.js": {
+      "browser": "./dist/bundle.esm.min.js",
+      "require": "./dist/bundle.esm.min.js",
+      "node": "./dist/bundle.esm.min.js"
     }
   },
   "browser": {


### PR DESCRIPTION
This is the nft.storage equivalent of  https://github.com/web3-storage/web3.storage/pull/930. It adds `./dist/bundle.esm.min.js` to the package exports to fix production builds that use the pre-bundled lib.
