### PR TITLE
feat: gateway track redirect counts

### DIFF
--- a/packages/gateway/src/constants.js
+++ b/packages/gateway/src/constants.js
@@ -2,6 +2,7 @@ export const CF_CACHE_MAX_OBJECT_SIZE = 512 * Math.pow(1024, 2) // 512MB to byte
 export const METRICS_CACHE_MAX_AGE = 10 * 60 // in seconds (10 minutes)
 export const CIDS_TRACKER_ID = 'cids'
 export const SUMMARY_METRICS_ID = 'summary-metrics'
+export const REDIRECT_COUNTER_METRICS_ID = 'redirect-counter-metrics'
 export const HTTP_STATUS_RATE_LIMITED = 429
 export const HTTP_STATUS_SUCCESS = 200
 export const REQUEST_PREVENTED_RATE_LIMIT_CODE = 'RATE_LIMIT'

--- a/packages/gateway/src/durable-objects/gateway-redirect-counter.js
+++ b/packages/gateway/src/durable-objects/gateway-redirect-counter.js
@@ -1,0 +1,34 @@
+/**
+ * Durable Object for tracking Gateway Redirect counts.
+ */
+export class GatewayRedirectCounter0 {
+  constructor(state) {
+    this.state = state
+
+    this.state.blockConcurrencyWhile(async () => {
+      const stored = await this.state.storage.get('value')
+      // After initialization, future reads do not need to access storage.
+      this.value = stored || 0
+    })
+  }
+
+  // Handle HTTP requests from clients.
+  async fetch(request) {
+    // Apply requested action.
+    let url = new URL(request.url)
+    switch (url.pathname) {
+      case '/update':
+        this.value++
+        await this.state.storage.put('value', this.value)
+        return new Response()
+      case '/metrics':
+        return new Response(
+          JSON.stringify({
+            gatewayRedirectCount: this.value,
+          })
+        )
+      default:
+        return new Response('Not found', { status: 404 })
+    }
+  }
+}

--- a/packages/gateway/src/env.js
+++ b/packages/gateway/src/env.js
@@ -18,6 +18,7 @@ import { Logging } from './logs.js'
  * @property {Object} SUMMARYMETRICS
  * @property {Object} CIDSTRACKER
  * @property {Object} GATEWAYRATELIMITS
+ * @property {Object} GATEWAYREDIRECTCOUNTER
  *
  * @typedef {Object} EnvTransformed
  * @property {Array<string>} ipfsGateways
@@ -25,6 +26,7 @@ import { Logging } from './logs.js'
  * @property {Object} summaryMetricsDurable
  * @property {Object} cidsTrackerDurable
  * @property {Object} gatewayRateLimitsDurable
+ * @property {Object} gatewayRedirectCounter
  * @property {Toucan} [sentry]
  * @property {Logging} [log]
  *
@@ -43,6 +45,7 @@ export function envAll(request, env, ctx) {
   env.summaryMetricsDurable = env.SUMMARYMETRICS
   env.cidsTrackerDurable = env.CIDSTRACKER
   env.gatewayRateLimitsDurable = env.GATEWAYRATELIMITS
+  env.gatewayRedirectCounter = env.GATEWAYREDIRECTCOUNTER
   env.REQUEST_TIMEOUT = env.REQUEST_TIMEOUT || 20000
 
   env.log = new Logging(request, env, ctx)

--- a/packages/gateway/src/gateway.js
+++ b/packages/gateway/src/gateway.js
@@ -11,6 +11,7 @@ import {
   ABORT_ERR_CODE,
   CIDS_TRACKER_ID,
   SUMMARY_METRICS_ID,
+  REDIRECT_COUNTER_METRICS_ID,
   CF_CACHE_MAX_OBJECT_SIZE,
   HTTP_STATUS_RATE_LIMITED,
   REQUEST_PREVENTED_RATE_LIMIT_CODE,
@@ -100,6 +101,13 @@ export async function gatewayGet(request, env, ctx) {
   } catch (err) {
     const responses = await pSettle(gatewayReqs)
 
+    // Redirect if all failed with rate limited error
+    const wasRateLimited = responses.every(
+      (r) =>
+        r.value?.response?.status === HTTP_STATUS_RATE_LIMITED ||
+        r.value?.requestPreventedCode === REQUEST_PREVENTED_RATE_LIMIT_CODE
+    )
+
     ctx.waitUntil(
       (async () => {
         // Update metrics as all requests failed
@@ -108,14 +116,8 @@ export async function gatewayGet(request, env, ctx) {
             updateGatewayMetrics(request, env, r.value, false)
           )
         )
+        wasRateLimited && updateGatewayRedirectCounter(request, env)
       })()
-    )
-
-    // Redirect if all failed with rate limited error
-    const wasRateLimited = responses.every(
-      (r) =>
-        r.value?.response?.status === HTTP_STATUS_RATE_LIMITED ||
-        r.value?.requestPreventedCode === REQUEST_PREVENTED_RATE_LIMIT_CODE
     )
 
     if (wasRateLimited) {
@@ -243,6 +245,17 @@ async function updateSummaryCacheMetrics(request, env, response, responseTime) {
   await stub.fetch(
     getDurableRequestUrl(request, 'metrics/cache', contentLengthStats)
   )
+}
+/**
+ * @param {Request} request
+ * @param {import('./env').Env} env
+ */
+async function updateGatewayRedirectCounter(request, env) {
+  // Get durable object for counter
+  const id = env.gatewayRedirectCounter.idFromName(REDIRECT_COUNTER_METRICS_ID)
+  const stub = env.gatewayRedirectCounter.get(id)
+
+  await stub.fetch(getDurableRequestUrl(request, 'update'))
 }
 
 /**

--- a/packages/gateway/src/index.js
+++ b/packages/gateway/src/index.js
@@ -10,6 +10,7 @@ export { GatewayMetrics0 } from './durable-objects/gateway-metrics.js'
 export { SummaryMetrics1 } from './durable-objects/summary-metrics.js'
 export { CidsTracker0 } from './durable-objects/cids.js'
 export { GatewayRateLimits0 } from './durable-objects/gateway-rate-limits.js'
+export { GatewayRedirectCounter0 } from './durable-objects/gateway-redirect-counter.js'
 
 import { addCorsHeaders, withCorsHeaders } from './cors.js'
 import { errorHandler } from './error-handler.js'

--- a/packages/gateway/src/metrics.js
+++ b/packages/gateway/src/metrics.js
@@ -5,6 +5,7 @@ import pMap from 'p-map'
 import {
   METRICS_CACHE_MAX_AGE,
   SUMMARY_METRICS_ID,
+  REDIRECT_COUNTER_METRICS_ID,
   HTTP_STATUS_SUCCESS,
 } from './constants.js'
 import { responseTimeHistogram } from './utils/histogram.js'
@@ -17,6 +18,7 @@ import { contentLengthHistogram } from './durable-objects/summary-metrics.js'
  * @typedef MetricsDurable
  * @property {SummaryMetrics} summaryMetrics
  * @property {Record<string,GatewayMetrics>} ipfsGateways
+ * @property {number} gatewayRedirectCount
  */
 
 /**
@@ -37,31 +39,43 @@ export async function metricsGet(request, env, ctx) {
   // }
   let res
 
-  const [summaryMetrics, ipfsGateways] = await Promise.all([
-    (async () => {
-      const id = env.summaryMetricsDurable.idFromName(SUMMARY_METRICS_ID)
-      const stub = env.summaryMetricsDurable.get(id)
+  const [summaryMetrics, ipfsGateways, gatewayRedirectCount] =
+    await Promise.all([
+      (async () => {
+        const id = env.summaryMetricsDurable.idFromName(SUMMARY_METRICS_ID)
+        const stub = env.summaryMetricsDurable.get(id)
 
-      const stubResponse = await stub.fetch(request)
-      /** @type {SummaryMetrics} */
-      const summaryMetrics = await stubResponse.json()
+        const stubResponse = await stub.fetch(request)
+        /** @type {SummaryMetrics} */
+        const summaryMetrics = await stubResponse.json()
 
-      return summaryMetrics
-    })(),
-    pMap(env.ipfsGateways, async (gw) => {
-      const id = env.gatewayMetricsDurable.idFromName(gw)
-      const stub = env.gatewayMetricsDurable.get(id)
+        return summaryMetrics
+      })(),
+      pMap(env.ipfsGateways, async (gw) => {
+        const id = env.gatewayMetricsDurable.idFromName(gw)
+        const stub = env.gatewayMetricsDurable.get(id)
 
-      const stubResponse = await stub.fetch(request)
-      /** @type {GatewayMetrics} */
-      const gwMetrics = await stubResponse.json()
+        const stubResponse = await stub.fetch(request)
+        /** @type {GatewayMetrics} */
+        const gwMetrics = await stubResponse.json()
 
-      return {
-        gwMetrics,
-        gw,
-      }
-    }),
-  ])
+        return {
+          gwMetrics,
+          gw,
+        }
+      }),
+      (async () => {
+        const id = env.gatewayRedirectCounter.idFromName(
+          REDIRECT_COUNTER_METRICS_ID
+        )
+        const stub = env.gatewayRedirectCounter.get(id)
+
+        const stubResponse = await stub.fetch(request)
+        const { gatewayRedirectCount } = await stubResponse.json()
+
+        return gatewayRedirectCount
+      })(),
+    ])
 
   /** @type {MetricsDurable} */
   const metricsCollected = {
@@ -70,6 +84,7 @@ export async function metricsGet(request, env, ctx) {
       (obj, item) => Object.assign(obj, { [item.gw]: item.gwMetrics }),
       {}
     ),
+    gatewayRedirectCount,
   }
 
   const totalResponsesPerGateway = []
@@ -251,6 +266,9 @@ export async function metricsGet(request, env, ctx) {
     `# HELP nftgateway_cached_responses_content_length_bytes_total Accumulated content length of delivered cached responses`,
     `# TYPE nftgateway_cached_responses_content_length_bytes_total summary`,
     `nftgateway_cached_responses_content_length_bytes_total{env="${env.ENV}"} ${metricsCollected.summaryMetrics.totalCachedContentLengthBytes}`,
+    `# HELP nftgateway_redirect_total Total redirects to gateway.`,
+    `# TYPE nftgateway_redirect_total counter`,
+    `nftgateway_redirect_total{env="${env.ENV}"} ${metricsCollected.gatewayRedirectCount}`,
   ].join('\n')
 
   res = new Response(metrics, {

--- a/packages/gateway/wrangler.toml
+++ b/packages/gateway/wrangler.toml
@@ -21,7 +21,8 @@ bindings = [
   {name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"},
   {name = "SUMMARYMETRICS", class_name = "SummaryMetrics1"},
   {name = "CIDSTRACKER", class_name = "CidsTracker0"},
-  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits0"}
+  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits0"},
+  {name = "GATEWAYREDIRECTCOUNTER", class_name = "GatewayRedirectCounter0"}
 ]
 
 # PROD!
@@ -41,7 +42,8 @@ bindings = [
   {name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"},
   {name = "SUMMARYMETRICS", class_name = "SummaryMetrics1"},
   {name = "CIDSTRACKER", class_name = "CidsTracker0"},
-  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits0"}
+  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits0"},
+  {name = "GATEWAYREDIRECTCOUNTER", class_name = "GatewayRedirectCounter0"}
 ]
 
 # Staging!
@@ -61,7 +63,8 @@ bindings = [
   {name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"},
   {name = "SUMMARYMETRICS", class_name = "SummaryMetrics1"},
   {name = "CIDSTRACKER", class_name = "CidsTracker0"},
-  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits0"}
+  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits0"},
+  {name = "GATEWAYREDIRECTCOUNTER", class_name = "GatewayRedirectCounter0"}
 ]
 
 # Test!
@@ -78,7 +81,8 @@ bindings = [
   {name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"},
   {name = "SUMMARYMETRICS", class_name = "SummaryMetrics1"},
   {name = "CIDSTRACKER", class_name = "CidsTracker0"},
-  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits0"}
+  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits0"},
+  {name = "GATEWAYREDIRECTCOUNTER", class_name = "GatewayRedirectCounter0"}
 ]
 
 # Dev!
@@ -94,7 +98,8 @@ bindings = [
   {name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"},
   {name = "SUMMARYMETRICS", class_name = "SummaryMetrics1"},
   {name = "CIDSTRACKER", class_name = "CidsTracker0"},
-  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits0"}
+  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits0"},
+  {name = "GATEWAYREDIRECTCOUNTER", class_name = "GatewayRedirectCounter0"}
 ]
 
 [[migrations]]
@@ -104,3 +109,6 @@ new_classes = ["GatewayMetrics0", "SummaryMetrics0", "CidsTracker0", "GatewayRat
 tag = "v2" # Should be unique for each entry
 new_classes = ["SummaryMetrics1"]
 deleted_classes = ["SummaryMetrics0"]
+[[migrations]]
+tag = "v3" # Should be unique for each entry
+new_classes = ["GatewayRedirectCounter0"]


### PR DESCRIPTION
Adds a counter to track redirects when rate limited to have a metric and better view if all fail in any situation.