### PR TITLE
clarify file size/upload limits

### DIFF
--- a/packages/website/lib/faqContent.js
+++ b/packages/website/lib/faqContent.js
@@ -48,8 +48,11 @@ const faqContent = {
   ),
   nftSizeRestrictions: (
     <p className="lh-copy white mb4">
-      NFT.Storage can store NFTs up to <strong>31GiB </strong>
-      in size!
+      NFT.Storage accepts storage requests up to <strong>31GiB</strong> in size! Each upload can include a single file or a directory of files. (If you are using the HTTP API, you'll need to do some manual splitting for files over 100MB. See the{' '}
+      <Link href="/api-docs">
+        <a className="white">HTTP API docs</a>
+      </Link>{' '}
+      for details.)
     </p>
   ),
   nftBestPractices: (

--- a/packages/website/lib/faqContent.js
+++ b/packages/website/lib/faqContent.js
@@ -48,7 +48,7 @@ const faqContent = {
   ),
   nftSizeRestrictions: (
     <p className="lh-copy white mb4">
-      NFT.Storage accepts storage requests up to <strong>31GiB</strong> in size! Each upload can include a single file or a directory of files. (If you are using the HTTP API, you'll need to do some manual splitting for files over 100MB. See the{' '}
+      NFT.Storage accepts storage requests up to <strong>31GiB</strong> in size! Each upload can include a single file or a directory of files. (If you are using the HTTP API, you&apos;ll need to do some manual splitting for files over 100MB. See the{' '}
       <Link href="/api-docs">
         <a className="white">HTTP API docs</a>
       </Link>{' '}

--- a/packages/website/lib/faqContent.js
+++ b/packages/website/lib/faqContent.js
@@ -52,7 +52,7 @@ const faqContent = {
       <Link href="/api-docs">
         <a className="white">HTTP API docs</a>
       </Link>{' '}
-      for details.)
+      for details.) Currently, the rate limit is 1,000 requests per IP per hour.
     </p>
   ),
   nftBestPractices: (

--- a/packages/website/pages/faq.js
+++ b/packages/website/pages/faq.js
@@ -37,7 +37,7 @@ const faqs = [
     content: faqContent.dataStorageLength,
   },
   {
-    question: 'Are there any size restrictions for stored NFTs?',
+    question: 'What are the upload or file size restrictions on NFT.storage?',
     content: faqContent.nftSizeRestrictions,
   },
   {


### PR DESCRIPTION
clarify that the 31gib limit is per upload, and note the extra step required for http api users