### PR TITLE
Adding user_tag table to facilitate user restricted application features.

### DIFF
--- a/packages/api/db/tables.sql
+++ b/packages/api/db/tables.sql
@@ -7,6 +7,14 @@ CREATE TYPE auth_key_blocked_status_type AS ENUM (
     'Unblocked'
 );
 
+-- User tags are associated to a user for the purpose of granting/restricting them
+-- in the application.
+CREATE TYPE user_tag_type AS ENUM
+(
+  'PINNING',
+  'STORAGE_LIMIT'
+);
+
 -- Pin status type is a subset of IPFS Cluster "TrackerStatus".
 -- https://github.com/ipfs/ipfs-cluster/blob/54c3608899754412861e69ee81ca8f676f7e294b/api/types.go#L52-L83
 CREATE TYPE pin_status_type AS ENUM (
@@ -60,6 +68,17 @@ CREATE TABLE IF NOT EXISTS public.user
     github         jsonb,
     inserted_at    TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
     updated_at     TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.user_tag
+(
+  id              BIGSERIAL PRIMARY KEY,
+  user_id         BIGINT                                                        NOT NULL REFERENCES public.user (id),
+  tag             user_tag_type                                                 NOT NULL,
+  -- tag_value is useful for certain tags like STORAGE_LIMIT e.g. tag="STORAGE_LIMIT", tag_value="1TB"
+  tag_value       TEXT                                                                  ,
+  inserted_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now())     NOT NULL,
+  deleted_at  TIMESTAMP WITH TIME ZONE
 );
 
 CREATE INDEX IF NOT EXISTS user_updated_at_idx ON public.user (updated_at);


### PR DESCRIPTION
* pinning allowlist and user account storage limits can be managed by this single table without the need for one-off tables e.g. pinning_authorization.
* this allows the admin.storage site to easily manage tags.

web3 pr [here](https://github.com/web3-storage/web3.storage/pull/955)