### PR TITLE
feat: use Cluster statusAll method

### DIFF
--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -21,7 +21,7 @@
   "author": "Alan Shaw",
   "license": "(Apache-2.0 OR MIT)",
   "dependencies": {
-    "@nftstorage/ipfs-cluster": "^3.4.3",
+    "@nftstorage/ipfs-cluster": "^4.0.0",
     "debug": "^4.3.2",
     "dotenv": "^10.0.0",
     "form-data": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2939,6 +2939,11 @@
   resolved "https://registry.yarnpkg.com/@nftstorage/ipfs-cluster/-/ipfs-cluster-3.4.3.tgz#d29566d062cab187e26694ff337d105e8c2d3228"
   integrity sha512-SgqXQFpeOy+cR0NCxaNKuXTfCG2j+xGmzEgHDwsQZv/kriHZQPPPUJ8crekKR/Y8IZS59GUmz+vJ+CGQnmoHMg==
 
+"@nftstorage/ipfs-cluster@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@nftstorage/ipfs-cluster/-/ipfs-cluster-4.0.0.tgz#245a0cb733050c5b0d3811cee69ad4040cf38672"
+  integrity sha512-PEt85HJdXpmQ8PULbC7iDdtf12KrM9tblR+o/2k+/0pvcpAdrplJeTQkUiEGRBiyeevjFXvyMs0f/eGpfxBBgA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"


### PR DESCRIPTION
This PR switches to using the new `statusAll` method on cluster which now allows us to get the status for a given set of CIDs.

Due to nginx restrictions on request length we currently have to ask for 120 at a time. However it is significantly better than making 120 separate requests.