### PR TITLE
fix: gateway link for nft type uploads

### DIFF
--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -406,12 +406,9 @@ export default function Files({ user }) {
  *
  * @param {{cid: string, type?: string}} props
  */
-function GatewayLink({ cid }) {
-  // const gatewayLink = cid.startsWith('Qm')
-  //   ? `https://ipfs.io/ipfs/${cid}`
-  //   : `ipfs://${cid}`
-  // const href = type === 'nft' ? `${gatewayLink}/metadata.json` : gatewayLink
-  const href = `https://ipfs.io/ipfs/${cid}`
+function GatewayLink({ cid, type }) {
+  const gatewayLink = `https://ipfs.io/ipfs/${cid}`
+  const href = type === 'nft' ? `${gatewayLink}/metadata.json` : gatewayLink
   return (
     <a title="View IPFS Url" href={href} target="_blank" rel="noreferrer">
       View


### PR DESCRIPTION
Fixes regression where NFT type uploads do not link to the `metadata.json` file on the gateway.