### PR TITLE
Fix/issue 1174 add tooltips table headers

### DIFF
--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -332,9 +332,76 @@ export default function Files({ user }) {
                       <thead>
                         <tr className="bg-nsgray">
                           <th className="">Date</th>
-                          <th className="">CID</th>
-                          <th className="">Pin Status</th>
-                          <th className="">Storage Providers</th>
+                          <th className="">
+                            <span aria-describedby="cid-tooltip">
+                              CID
+                              <Tooltip
+                                placement="top"
+                                overlay={
+                                  <span>
+                                    The content identifier for a file or piece
+                                    of data.{' '}
+                                    <a
+                                      href="https://nftschool.dev/concepts/content-addressing/"
+                                      target="_blank"
+                                      rel="noreferrer"
+                                    >
+                                      Learn more
+                                    </a>
+                                  </span>
+                                }
+                                overlayClassName="table-tooltip"
+                                id="cid-tooltip"
+                              >
+                                <VscQuestion size={16} className="" />
+                              </Tooltip>
+                            </span>
+                          </th>
+                          <th className="">
+                            <span aria-describedby="pin-status-tooltip">
+                              Pin Status
+                              <Tooltip
+                                placement="top"
+                                overlay={
+                                  <span>
+                                    Reports the status of a file or piece of
+                                    data stored on the IPFS Cluster. Status
+                                    might not be fully up-to-date. Data is still
+                                    available even when still in Queued state.
+                                  </span>
+                                }
+                                overlayClassName="table-tooltip"
+                                id="pin-status-tooltip"
+                              >
+                                <VscQuestion size={16} className="" />
+                              </Tooltip>
+                            </span>
+                          </th>
+                          <th className="">
+                            <span aria-describedby="pin-status-tooltip">
+                              Storage Providers
+                              <Tooltip
+                                placement="top"
+                                overlay={
+                                  <span>
+                                    Service providers offering storage capacity
+                                    to the Filecoin network.{' '}
+                                    <a
+                                      href="https://nftschool.dev/concepts/content-persistence/"
+                                      target="_blank"
+                                      rel="noreferrer"
+                                    >
+                                      Learn more
+                                    </a>
+                                  </span>
+                                }
+                                overlayClassName="table-tooltip"
+                                id="pin-status-tooltip"
+                              >
+                                <VscQuestion size={16} className="" />
+                              </Tooltip>
+                            </span>
+                          </th>
                           <th className="">Size</th>
                           <th className="">
                             <span className="sr-only">File Actions</span>

--- a/packages/website/styles/table.css
+++ b/packages/website/styles/table.css
@@ -22,6 +22,14 @@
 }
 .table-responsive table tr th {
   display: none;
+  white-space: nowrap;
+}
+.table-responsive table tr th > span {
+  display: flex;
+  align-items: center;
+}
+.table-responsive table tr th > span > svg {
+  padding: 2px 0 0 2px;
 }
 .table-responsive table tr {
   margin-bottom: 0.5rem;
@@ -204,4 +212,9 @@
 .actions-trigger--active {
   background-color: #000;
   color: #fff;
+}
+
+.rc-tooltip.table-tooltip .rc-tooltip-content a,
+.rc-tooltip.table-tooltip .rc-tooltip-content a:visited {
+  color: #000;
 }


### PR DESCRIPTION
Add table header tooltips for #1174 
<img width="906" alt="Screen Shot 2022-02-07 at 11 46 34 AM" src="https://user-images.githubusercontent.com/1189523/152860602-59bafb81-a720-47aa-8287-2bf7f63212cc.png">
