### PR TITLE
fix(website): fix rate limit definition in FAQ

### DIFF
--- a/packages/website/lib/faqContent.js
+++ b/packages/website/lib/faqContent.js
@@ -48,11 +48,16 @@ const faqContent = {
   ),
   nftSizeRestrictions: (
     <p className="lh-copy white mb4">
-      NFT.Storage accepts storage requests up to <strong>31GiB</strong> in size! Each upload can include a single file or a directory of files. (If you are using the HTTP API, you&apos;ll need to do some manual splitting for files over 100MB. See the{' '}
+      NFT.Storage accepts storage requests up to <strong>31GiB</strong> in size!
+      Each upload can include a single file or a directory of files. (If you are
+      using the HTTP API, you&apos;ll need to do some manual splitting for files
+      over 100MB. See the{' '}
       <Link href="/api-docs">
         <a className="white">HTTP API docs</a>
       </Link>{' '}
-      for details.) Currently, the rate limit is 1,000 requests per IP per hour.
+      for details.) Currently, the rate limit will be triggered if the API
+      receives more than 30 requests using the same API key within a ten second
+      window.
     </p>
   ),
   nftBestPractices: (

--- a/packages/website/lib/faqContent.js
+++ b/packages/website/lib/faqContent.js
@@ -56,7 +56,7 @@ const faqContent = {
         <a className="white">HTTP API docs</a>
       </Link>{' '}
       for details.) Currently, the rate limit will be triggered if the API
-      receives more than 30 requests using the same API key within a ten second
+      receives more than 30 requests using the same API key within a 10 second
       window.
     </p>
   ),


### PR DESCRIPTION
This updates the FAQ entry about rate limits with the correct per-token limit.