### PR TITLE
fix: gateway get headers record

### DIFF
--- a/packages/gateway/src/gateway.js
+++ b/packages/gateway/src/gateway.js
@@ -210,11 +210,13 @@ async function gatewayFetch(
  * @param {Request} request
  */
 function getHeaders(request) {
-  const existingProxies = request.headers['X-Forwarded-For']
-    ? `, ${request.headers['X-Forwarded-For']}`
+  const existingProxies = request.headers.get('X-Forwarded-For')
+    ? `, ${request.headers.get('X-Forwarded-For')}`
     : ''
   return {
-    'X-Forwarded-For': `${request.headers['cf-connecting-ip']}${existingProxies}`,
+    'X-Forwarded-For': `${request.headers.get(
+      'cf-connecting-ip'
+    )}${existingProxies}`,
   }
 }
 


### PR DESCRIPTION
Fixes get headers function to use the `.get` function. While `['X-Forwarded-For']` was working, `['cf-connecting-ip']` was not working and it was resulting on  `undefined,...` https://github.com/protocol/bifrost-infra/issues/1609#issuecomment-1032018181

This fixes it, already tested