### PR TITLE
fix: blog post date

### DIFF
--- a/packages/website/posts/2022-02-08-what-am-buying.mdx
+++ b/packages/website/posts/2022-02-08-what-am-buying.mdx
@@ -3,7 +3,7 @@ title: 'When you buy an NFT, what are you actually getting?'
 description: Behind the glamour, NFTs are more like hyperlinks than like files.
 author: J Chris Anderson
 thumbnail: https://user-images.githubusercontent.com/97632209/152211576-fc45bee4-9afe-470b-9b81-92435d151b83.png
-date: Jan 25, 2022
+date: Feb 08, 2022
 tags:
   - culture
 ---


### PR DESCRIPTION
Otherwise blog post appears in the middle of the list and is not "featured" at the top of the page.

<img width="1624" alt="Screenshot 2022-02-08 at 09 53 32" src="https://user-images.githubusercontent.com/152863/152962895-5288db5b-347d-402f-b755-152a07515903.png">

In the futurem please check the preview link before merging so doesn't happen again.
