### PR TITLE
fix: line height for storage providers

### DIFF
--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -212,7 +212,7 @@ export default function Files({ user }) {
           {nft.pin.status.charAt(0).toUpperCase() + nft.pin.status.slice(1)}
         </td>
         <td data-label="Deals">
-          <div>{deals}</div>
+          <div className="lh-copy">{deals}</div>
         </td>
         <td data-label="Size" className="nowrap">
           {bytes(nft.size || 0)}


### PR DESCRIPTION
Before:
<img width="1398" alt="Screenshot 2022-02-08 at 11 19 19" src="https://user-images.githubusercontent.com/152863/152977377-fd225cba-6eed-4fa8-b1c4-4129c2ce451c.png">

After:
<img width="1414" alt="Screenshot 2022-02-08 at 11 19 42" src="https://user-images.githubusercontent.com/152863/152977386-f242b964-7989-458d-8124-214ebc304c33.png">

