### PR TITLE
fix: tweak rate limits per gateway

### DIFF
--- a/packages/gateway/src/durable-objects/gateway-rate-limits.js
+++ b/packages/gateway/src/durable-objects/gateway-rate-limits.js
@@ -65,7 +65,8 @@ export class GatewayRateLimits0 {
   }
 }
 
-const MINUTE = 1000 * 60
+const SECOND = 1000
+const MINUTE = SECOND * 60
 
 /**
  * Get rate limiting characteristics of a given Gateway.
@@ -82,12 +83,12 @@ function getRateLimitingCharacteristics(gatewayUrl) {
       }
     case 'https://cf-ipfs.com':
       return {
-        RATE_LIMIT_REQUESTS: 100,
-        RATE_LIMIT_TIMEFRAME: MINUTE,
+        RATE_LIMIT_REQUESTS: 16,
+        RATE_LIMIT_TIMEFRAME: SECOND * 10,
       }
     case 'https://nft-storage.mypinata.cloud/':
       return {
-        RATE_LIMIT_REQUESTS: 200,
+        RATE_LIMIT_REQUESTS: 400,
         RATE_LIMIT_TIMEFRAME: MINUTE,
       }
     // Default to 100


### PR DESCRIPTION
Per previous load experiments and talks with Pinata team, let's change the rate limit prevention criterium

Cloudflare was in theory 100 req / minute, but I got cases where I got rate limited by 30 fast requests... I did a small test using 16 req / 10 seconds instead, and it seem way more stable.

Pinata does not rate limit dedicated gateways. This might change in the future, but as an enterprise customer they will reach out first and will try to get a solution together with us if it would start to be rate limited. Suggesting doubling what they offer on their public gateway and we can see later on if we can increase more