### PR TITLE
fix: path with file and extension

### DIFF
--- a/packages/gateway/src/gateway.js
+++ b/packages/gateway/src/gateway.js
@@ -364,16 +364,12 @@ async function updateCidsTracker(request, env, responses, cid) {
  * @param {any} [data]
  */
 function getDurableRequestUrl(request, route, data) {
-  const reqUrl = new URL(
-    route,
-    request.url.startsWith('http') || request.url.startsWith('https')
-      ? request.url
-      : `https://${request.url}`
-  )
+  const reqUrl = new URL(request.url)
+  const durableReqUrl = new URL(route, `${reqUrl.protocol}//${reqUrl.host}`)
   const headers = new Headers()
   headers.append('Content-Type', 'application/json')
 
-  return new Request(reqUrl.toString(), {
+  return new Request(durableReqUrl.toString(), {
     headers,
     method: 'PUT',
     body: data && JSON.stringify(data),


### PR DESCRIPTION
When URLs are like https://bafybeifvsmjgbhck72pabliifeo35cew5yhxujfqjxg4g32vr3yv24h6zu.ipfs-staging.nft.storage/path/file.txt the durable object request url was getting `/path/request`. Changing it to allow any type of request