### PR TITLE
fix capitalization of URL

### DIFF
--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -426,8 +426,8 @@ function GatewayLink({ cid, type }) {
   const gatewayLink = `https://ipfs.io/ipfs/${cid}`
   const href = type === 'nft' ? `${gatewayLink}/metadata.json` : gatewayLink
   return (
-    <a title="View IPFS Url" href={href} target="_blank" rel="noreferrer">
-      View
+    <a title="View IPFS URL" href={href} target="_blank" rel="noreferrer">
+      View URL
     </a>
   )
 }
@@ -445,12 +445,12 @@ function CopyGatewayLink({ cid, type }) {
 
   return (
     <CopyButton
-      title="Copy IPFS Url to Clipboard"
+      title="Copy IPFS URL to Clipboard"
       text={href}
-      popupContent={'IPFS Url has been copied!'}
+      popupContent={'IPFS URL has been copied!'}
       asLink={true}
     >
-      <>Copy IPFS Url</>
+      <>Copy IPFS URL</>
     </CopyButton>
   )
 }


### PR DESCRIPTION
Fixes capitalization of "URL" in action menu.

<img width="840" alt="URL-1" src="https://user-images.githubusercontent.com/43380153/153226109-ca44e6c6-0295-4573-a53d-a4d7874a8cb9.png">
<img width="840" alt="URL-2" src="https://user-images.githubusercontent.com/43380153/153226121-4cbdb213-e94e-4621-9362-7037f6b3f58b.png">
<img width="840" alt="URL-3" src="https://user-images.githubusercontent.com/43380153/153226127-388d21be-3ee0-46ae-a8b0-c0eb9eecf09b.png">
<img width="840" alt="URL-4" src="https://user-images.githubusercontent.com/43380153/153226131-f9ce0933-7ea2-4c82-9d11-722af6ebe246.png">
