### PR TITLE
fix: callout overflow issue on /docs mobile

### DIFF
--- a/packages/website/styles/nextra-overrides.css
+++ b/packages/website/styles/nextra-overrides.css
@@ -2,6 +2,10 @@
   max-width: 100%;
 }
 
+.docs-container .callout {
+  overflow: auto;
+}
+
 @media (min-width: 768px) {
   .nextra-container nav.flex {
     display: none;


### PR DESCRIPTION
Fixes callout overflow issue on mobile

![before](https://user-images.githubusercontent.com/43380153/153285111-bac16c4c-f327-423a-af40-4a2c63640001.png)

![after](https://user-images.githubusercontent.com/43380153/153285098-e4301226-5937-44a1-a90b-f3df038c35e4.png)

