### PR TITLE
fix: increase gateway timeout

### DIFF
--- a/packages/gateway/src/gateway.js
+++ b/packages/gateway/src/gateway.js
@@ -178,7 +178,7 @@ async function gatewayFetch(
   cid,
   request,
   env,
-  { pathname = '', timeout = 20000 } = {}
+  { pathname = '', timeout = 60000 } = {}
 ) {
   // Block before hitting rate limit if needed
   const { shouldBlock } = await getGatewayRateLimitState(request, env, gwUrl)


### PR DESCRIPTION
This PR increases gateway timeout to 60s (same as ipfs.io)

I was talking last night with @dchoi27 and we should increase the timeout as we might not have data in Peered Cluster nodes, and need to perform DHT lookups. This is particularly important for users that store their data in Pinning Services.

I was looking into `cf-ipfs` and `pinata` dedicated gateway timeouts and they are bigger than 60s. But I think 60s should be a reasonable timeout to have.