### PR TITLE
Fixed broken link

### DIFF
--- a/packages/website/pages/docs/quickstart.md
+++ b/packages/website/pages/docs/quickstart.md
@@ -229,7 +229,7 @@ The `url` is an IPFS url that can be viewed with [Brave](https://brave.com) and 
 [reference-http-api]: https://nft.storage/api-docs/
 [concepts-car-files]: ./concepts/car-files/
 [howto-retrieve]: ./how-to/retrieve/
-[js-client]: ./client/lib.md
+[js-client]: ./client/lib/
 
 [mdn-file]: https://developer.mozilla.org/en-US/docs/Web/API/File
 


### PR DESCRIPTION
Fixes the broken link for javascript client lib, inside of quickstart.