### PR TITLE
Revert "Fixed broken link"

### DIFF
--- a/packages/website/pages/docs/quickstart.md
+++ b/packages/website/pages/docs/quickstart.md
@@ -229,7 +229,7 @@ The `url` is an IPFS url that can be viewed with [Brave](https://brave.com) and 
 [reference-http-api]: https://nft.storage/api-docs/
 [concepts-car-files]: ./concepts/car-files/
 [howto-retrieve]: ./how-to/retrieve/
-[js-client]: ./client/lib/
+[js-client]: ./client/lib.md
 
 [mdn-file]: https://developer.mozilla.org/en-US/docs/Web/API/File
 


### PR DESCRIPTION
Revert, then new pr with correct format so it goes into website release as a fix

Reverts nftstorage/nft.storage#1339