### PR TITLE
chore: fix client-gen script and openapi schema

### DIFF
--- a/client-gen.sh
+++ b/client-gen.sh
@@ -5,7 +5,7 @@
 
 docker run --rm \
   -v ${PWD}:/local openapitools/openapi-generator-cli generate \
-  -i /local/website/public/schema.yml \
+  -i /local/packages/website/public/schema.yml \
   -g ruby \
   --api-name-suffix=API \
   --git-user-id=nftstorage \
@@ -20,7 +20,7 @@ docker run --rm \
 
 docker run --rm \
   -v ${PWD}:/local openapitools/openapi-generator-cli generate \
-  -i /local/website/public/schema.yml \
+  -i /local/packages/website/public/schema.yml \
   -g go \
   --api-name-suffix=API \
   --git-user-id=nftstorage \
@@ -32,7 +32,7 @@ docker run --rm \
 
 docker run --rm \
   -v ${PWD}:/local openapitools/openapi-generator-cli generate \
-  -i /local/website/public/schema.yml \
+  -i /local/packages/website/public/schema.yml \
   -g python \
   --api-name-suffix=API \
   --git-user-id=nftstorage \
@@ -45,7 +45,7 @@ docker run --rm \
 
 docker run --rm \
   -v ${PWD}:/local openapitools/openapi-generator-cli generate \
-  -i /local/website/public/schema.yml \
+  -i /local/packages/website/public/schema.yml \
   -g rust \
   --api-name-suffix=API \
   --git-user-id=nftstorage \
@@ -57,7 +57,7 @@ docker run --rm \
 
 docker run --rm \
   -v ${PWD}:/local openapitools/openapi-generator-cli generate \
-  -i /local/website/public/schema.yml \
+  -i /local/packages/website/public/schema.yml \
   -g php \
   --api-name-suffix=API \
   --git-user-id=nftstorage \
@@ -70,7 +70,7 @@ docker run --rm \
 
 docker run --rm \
   -v ${PWD}:/local openapitools/openapi-generator-cli generate \
-  -i /local/website/public/schema.yml \
+  -i /local/packages/website/public/schema.yml \
   -g java \
   --git-user-id=nftstorage \
   --git-repo-id=java-client \

--- a/packages/website/public/schema.yml
+++ b/packages/website/public/schema.yml
@@ -74,6 +74,21 @@ paths:
               additionalProperties:
                 type: string
                 format: binary
+      responses:
+        '200':
+          description: OK
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/UploadResponse'
+        '400':
+          $ref: '#/components/responses/badRequest'
+        '401':
+          $ref: '#/components/responses/unauthorized'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '500':
+          $ref: '#/components/responses/internalServerError'
 
   /upload:
     post:


### PR DESCRIPTION
This fixes the path to the schema file in `client-gen.sh`, and copies the `responses` section in the schema from the `upload` operation to `store`, to get rid of these errors:

```
Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 1, Warning count: 1
Errors: 
        -attribute paths.'/store'(post).responses is missing
Warnings: 
        -attribute paths.'/store'(post).responses is missing
```

closes #1370 