### PR TITLE
feat: gateway tracking requested cids in database

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -22,6 +22,7 @@
     "itty-router": "^2.4.5",
     "multiformats": "^9.6.4",
     "nanoid": "^3.1.30",
+    "nft.storage": "^6.0.0",
     "p-any": "^4.0.0",
     "p-map": "^5.3.0",
     "p-settle": "^5.0.0",

--- a/packages/gateway/src/durable-objects/summary-metrics.js
+++ b/packages/gateway/src/durable-objects/summary-metrics.js
@@ -1,22 +1,33 @@
+import { NFTStorage } from 'nft.storage'
+import { PinStatusMap } from '../utils/pins.js'
 import {
   responseTimeHistogram,
   createResponseTimeHistogramObject,
 } from '../utils/histogram.js'
 
 /**
+ * @typedef {'Stored'|'NotStored'} ContentStatus
+ * @typedef {import('../utils/pins').PinStatus} PinStatus
+ *
  * @typedef {Object} SummaryMetrics
  * @property {number} totalWinnerResponseTime total response time of the requests
  * @property {number} totalWinnerSuccessfulRequests total number of successful requests
  * @property {number} totalCachedResponseTime total response time to forward cached responses
  * @property {number} totalCachedResponses total number of cached responses
+ * @property {number} totalErroredResponsesWithKnownContent total responses errored with content in NFT.storage
  * @property {BigInt} totalContentLengthBytes total content length of responses
  * @property {BigInt} totalCachedContentLengthBytes total content length of cached responses
+ * @property {Record<ContentStatus, number>} totalResponsesByContentStatus
+ * @property {Record<PinStatus, number>} totalResponsesByPinStatus
  * @property {Record<string, number>} contentLengthHistogram
  * @property {Record<string, number>} responseTimeHistogram
+ * @property {Record<PinStatus, Record<string, number>>} responseTimeHistogramByPinStatus
  *
  * @typedef {Object} FetchStats
- * @property {number} responseTime number of milliseconds to get response
- * @property {number} contentLength content length header content
+ * @property {string} cid fetched CID
+ * @property {boolean} errored fetched CID request errored
+ * @property {number} [responseTime] number of milliseconds to get response
+ * @property {number} [contentLength] content length header content
  */
 
 // Key to track total time for winner gateway to respond
@@ -27,6 +38,9 @@ const TOTAL_WINNER_SUCCESSFUL_REQUESTS_ID = 'totalWinnerSuccessfulRequests'
 const TOTAL_CACHED_RESPONSE_TIME_ID = 'totalCachedResponseTime'
 // Key to track total cached requests
 const TOTAL_CACHED_RESPONSES_ID = 'totalCachedResponses'
+// Key to track total errored requests with known content
+const TOTAL_ERRORED_RESPONSES_WITH_KNOWN_CONTENT_ID =
+  'totalErroredResponsesWithKnownContent'
 // Key to track total content length of responses
 const TOTAL_CONTENT_LENGTH_BYTES_ID = 'totalContentLengthBytes'
 // Key to track total cached content length of responses
@@ -35,6 +49,13 @@ const TOTAL_CACHED_CONTENT_LENGTH_BYTES_ID = 'totalCachedContentLengthBytes'
 const CONTENT_LENGTH_HISTOGRAM_ID = 'contentLengthHistogram'
 // Key to track response time histogram
 const RESPONSE_TIME_HISTOGRAM_ID = 'responseTimeHistogram'
+// Key to track response time histogram by pin status
+const RESPONSE_TIME_HISTOGRAM_BY_PIN_STATUS_ID =
+  'responseTimeHistogramByPinStatus'
+// Key to track responses by content status
+const TOTAL_RESPONSES_BY_CONTENT_STATUS_ID = 'totalResponsesByContentStatus'
+// Key to track responses by pin status
+const TOTAL_RESPONSES_BY_PIN_STATUS_ID = 'totalResponsesByPinStatus'
 
 /**
  * Durable Object for keeping summary metrics of gateway.nft.storage
@@ -42,6 +63,8 @@ const RESPONSE_TIME_HISTOGRAM_ID = 'responseTimeHistogram'
 export class SummaryMetrics0 {
   constructor(state) {
     this.state = state
+    // @ts-ignore we don't need token just for check
+    this.nftStorageClient = new NFTStorage({})
 
     // `blockConcurrencyWhile()` ensures no requests are delivered until initialization completes.
     this.state.blockConcurrencyWhile(async () => {
@@ -57,22 +80,40 @@ export class SummaryMetrics0 {
       // Total cached requests
       this.totalCachedResponses =
         (await this.state.storage.get(TOTAL_CACHED_RESPONSES_ID)) || 0
-      // Total content length responses
+      // Total errored requests with known content
+      this.totalErroredResponsesWithKnownContent =
+        (await this.state.storage.get(
+          TOTAL_ERRORED_RESPONSES_WITH_KNOWN_CONTENT_ID
+        )) || 0
+      /** @type {BigInt} */
       this.totalContentLengthBytes =
         (await this.state.storage.get(TOTAL_CONTENT_LENGTH_BYTES_ID)) ||
         BigInt(0)
-      // Total cached content length responses
+      /** @type {BigInt} */
       this.totalCachedContentLengthBytes =
         (await this.state.storage.get(TOTAL_CACHED_CONTENT_LENGTH_BYTES_ID)) ||
         BigInt(0)
-      // Content length histogram
+      /** @type {Record<ContentStatus, number>} */
+      this.totalResponsesByContentStatus =
+        (await this.state.storage.get(TOTAL_RESPONSES_BY_CONTENT_STATUS_ID)) ||
+        createResponsesByContentStatusObject()
+      /** @type {Record<PinStatus, number>} */
+      this.totalResponsesByPinStatus =
+        (await this.state.storage.get(TOTAL_RESPONSES_BY_PIN_STATUS_ID)) ||
+        createResponsesByPinStatusObject()
+      /** @type {Record<string, number>} */
       this.contentLengthHistogram =
         (await this.state.storage.get(CONTENT_LENGTH_HISTOGRAM_ID)) ||
         createContentLengthHistogramObject()
-      // Response time histogram
+      /** @type {Record<string, number>} */
       this.responseTimeHistogram =
         (await this.state.storage.get(RESPONSE_TIME_HISTOGRAM_ID)) ||
         createResponseTimeHistogramObject()
+      /** @type {Record<PinStatus, Record<string, number>>} */
+      this.responseTimeHistogramByPinStatus =
+        (await this.state.storage.get(
+          RESPONSE_TIME_HISTOGRAM_BY_PIN_STATUS_ID
+        )) || createResponseTimeHistogramByPinStatusObject()
     })
   }
 
@@ -91,11 +132,17 @@ export class SummaryMetrics0 {
               totalWinnerSuccessfulRequests: this.totalWinnerSuccessfulRequests,
               totalCachedResponseTime: this.totalCachedResponseTime,
               totalCachedResponses: this.totalCachedResponses,
+              totalErroredResponsesWithKnownContent:
+                this.totalErroredResponsesWithKnownContent,
               totalContentLengthBytes: this.totalContentLengthBytes.toString(),
               totalCachedContentLengthBytes:
                 this.totalCachedContentLengthBytes.toString(),
+              totalResponsesByContentStatus: this.totalResponsesByContentStatus,
+              totalResponsesByPinStatus: this.totalResponsesByPinStatus,
               contentLengthHistogram: this.contentLengthHistogram,
               responseTimeHistogram: this.responseTimeHistogram,
+              responseTimeHistogramByPinStatus:
+                this.responseTimeHistogramByPinStatus,
             })
           )
         default:
@@ -106,15 +153,90 @@ export class SummaryMetrics0 {
     // POST
     /** @type {FetchStats} */
     const data = await request.json()
+    await Promise.all([
+      this._updateStatsMetrics(data, url),
+      this._updateCidMetrics(data),
+    ])
+
+    return new Response()
+  }
+
+  /**
+   * @param {FetchStats} data
+   */
+  async _updateCidMetrics({ cid, errored, responseTime }) {
+    try {
+      const statusRes = await this.nftStorageClient.check(cid)
+
+      if (errored) {
+        this.totalErroredResponsesWithKnownContent += 1
+
+        await this.state.storage.put(
+          TOTAL_ERRORED_RESPONSES_WITH_KNOWN_CONTENT_ID,
+          this.totalErroredResponsesWithKnownContent
+        )
+      } else {
+        this.totalResponsesByContentStatus['Stored'] += 1
+
+        const pinStatus = PinStatusMap[statusRes.pin?.status]
+        if (pinStatus) {
+          this.totalResponsesByPinStatus[pinStatus] += 1
+          this.responseTimeHistogramByPinStatus[pinStatus] =
+            getUpdatedHistogram(
+              this.responseTimeHistogramByPinStatus[pinStatus],
+              responseTimeHistogram,
+              responseTime
+            )
+        }
+
+        await Promise.all([
+          this.state.storage.put(
+            TOTAL_RESPONSES_BY_CONTENT_STATUS_ID,
+            this.totalResponsesByContentStatus
+          ),
+          pinStatus &&
+            this.state.storage.put(
+              TOTAL_RESPONSES_BY_PIN_STATUS_ID,
+              this.totalResponsesByPinStatus
+            ),
+          this.state.storage.put(
+            RESPONSE_TIME_HISTOGRAM_BY_PIN_STATUS_ID,
+            this.responseTimeHistogramByPinStatus
+          ),
+        ])
+      }
+    } catch (err) {
+      if (err.message === 'NFT not found') {
+        // Update not existing CID
+        this.totalResponsesByContentStatus['NotStored'] += 1
+
+        await this.state.storage.put(
+          TOTAL_RESPONSES_BY_CONTENT_STATUS_ID,
+          this.totalResponsesByContentStatus
+        )
+      }
+    }
+  }
+
+  /**
+   * @param {FetchStats} stats
+   * @param {URL} url
+   */
+  async _updateStatsMetrics(stats, url) {
+    // Errored does not have winner/cache metrics to update
+    if (stats.errored) {
+      return
+    }
+
     switch (url.pathname) {
       case '/metrics/winner':
-        await this._updateWinnerMetrics(data)
-        return new Response()
+        await this._updateWinnerMetrics(stats)
+        break
       case '/metrics/cache':
-        await this._updatedCacheMetrics(data)
-        return new Response()
+        await this._updatedCacheMetrics(stats)
+        break
       default:
-        return new Response('Not found', { status: 404 })
+        throw new Error('Not found')
     }
   }
 
@@ -196,48 +318,74 @@ export class SummaryMetrics0 {
    */
   _updateContentLengthMetrics(stats) {
     this.totalContentLengthBytes += BigInt(stats.contentLength)
-
-    // Update histogram
-    const tmpHistogram = {
-      ...this.contentLengthHistogram,
-    }
-
-    // Get all the histogram buckets where the content size is smaller
-    const histogramCandidates = contentLengthHistogram.filter(
-      (h) => stats.contentLength < h
+    this.contentLengthHistogram = getUpdatedHistogram(
+      this.contentLengthHistogram,
+      contentLengthHistogram,
+      stats.contentLength
     )
-    histogramCandidates.forEach((candidate) => {
-      tmpHistogram[candidate] += 1
-    })
-
-    this.contentLengthHistogram = tmpHistogram
   }
 
   /**
    * @param {FetchStats} stats
    */
   _updateResponseTimeHistogram(stats) {
-    const tmpHistogram = {
-      ...this.responseTimeHistogram,
-    }
-
-    // Get all the histogram buckets where the response time is smaller
-    const histogramCandidates = responseTimeHistogram.filter(
-      (h) => stats.responseTime < h
+    this.responseTimeHistogram = getUpdatedHistogram(
+      this.responseTimeHistogram,
+      responseTimeHistogram,
+      stats.responseTime
     )
+  }
+}
 
-    histogramCandidates.forEach((candidate) => {
-      tmpHistogram[candidate] += 1
+function getUpdatedHistogram(histogramData, histogramBuckets, value) {
+  const updatedHistogram = {
+    ...histogramData,
+  }
+  // Update all the histogram buckets where the response time is smaller
+  histogramBuckets
+    .filter((h) => value < h)
+    .forEach((candidate) => {
+      updatedHistogram[candidate] += 1
     })
 
-    this.responseTimeHistogram = tmpHistogram
-  }
+  return updatedHistogram
+}
+
+/**
+ * @return {Record<PinStatus, number>}
+ */
+function createResponsesByPinStatusObject() {
+  const e = Object.values(PinStatusMap).map((t) => [t, 0])
+  return Object.fromEntries(e)
+}
+
+/**
+ * @return {Record<ContentStatus, number>}
+ */
+function createResponsesByContentStatusObject() {
+  const e = contentStatus.map((t) => [t, 0])
+  return Object.fromEntries(e)
+}
+
+/**
+ * @return {Record<PinStatus, Record<string, number>>}
+ */
+function createResponseTimeHistogramByPinStatusObject() {
+  const pinStatusEntry = Object.values(PinStatusMap).map((t) => [
+    t,
+    createResponseTimeHistogramObject(),
+  ])
+
+  return Object.fromEntries(pinStatusEntry)
 }
 
 function createContentLengthHistogramObject() {
   const h = contentLengthHistogram.map((h) => [h, 0])
   return Object.fromEntries(h)
 }
+
+// Either CID is stored in NFT.storage or not
+export const contentStatus = ['Stored', 'NotStored']
 
 // We will count occurences per bucket where content size is less or equal than bucket value
 export const contentLengthHistogram = [

--- a/packages/gateway/src/utils/pins.js
+++ b/packages/gateway/src/utils/pins.js
@@ -1,0 +1,15 @@
+/**
+ * @typedef {
+ *  | 'PinError'
+ *  | 'Pinned'
+ *  | 'Pinning'
+ *  | 'PinQueued'} PinStatus
+ */
+
+/** @type {Record<string, PinStatus>} */
+export const PinStatusMap = {
+  pin_error: 'PinError',
+  pinned: 'Pinned',
+  pinning: 'Pinning',
+  pin_queued: 'PinQueued',
+}

--- a/packages/gateway/test/metrics.spec.js
+++ b/packages/gateway/test/metrics.spec.js
@@ -38,9 +38,23 @@ test('Gets Metrics content when empty state', async (t) => {
   )
   t.is(metricsResponse.includes(`_responses_content_length_total{le=`), true)
   t.is(
-    metricsResponse.includes(
-      `_responses_content_length_bytes_total{env="test"} 0`
-    ),
+    metricsResponse.includes(`_responses_by_pin_status_total{env="test"`),
+    true
+  )
+  t.is(
+    metricsResponse.includes(`_responses_by_content_status_total{env="test"`),
+    true
+  )
+  t.is(
+    metricsResponse.includes('_errored_responses_with_known_content_total'),
+    true
+  )
+  t.is(
+    metricsResponse.includes('nftgateway_winner_response_time_seconds_total'),
+    true
+  )
+  t.is(
+    metricsResponse.includes('nftgateway_winner_response_time_seconds_total'),
     true
   )
   gateways.forEach((gw) => {


### PR DESCRIPTION
This PR adds metrics tracking whether content was stored in NFT.storage and its Pinning status characteristics. It uses nft.storage client to check the state of the content. We could go through the route of directly connecting to the DB here, but as we do this in the waitUntil it seems cleaner to rely on the client (specially as we can't access replica directly).

Prometheus metrics to be consumed are as follows:
```
# HELP nftgateway_errored_responses_with_known_content_total errored requests with known content in NFT.storage.
# TYPE nftgateway_errored_responses_with_known_content_total counter
nftgateway_errored_responses_with_known_content_total{env="test"} 0
# HELP nftgateway_responses_by_content_status_total total of responses by content status. Either stored or not stored.
# TYPE nftgateway_responses_by_content_status_total counter
nftgateway_responses_by_content_status_total{env="test",status="Stored"} 0
nftgateway_responses_by_content_status_total{env="test",status="NotStored"} 0
# HELP nftgateway_responses_by_pin_status_total total of responses by pin status.
# TYPE nftgateway_responses_by_pin_status_total counter
nftgateway_responses_by_pin_status_total{env="test",status="PinError"} 0
nftgateway_responses_by_pin_status_total{env="test",status="Pinned"} 0
nftgateway_responses_by_pin_status_total{env="test",status="Pinning"} 0
nftgateway_responses_by_pin_status_total{env="test",status="PinQueued"} 0
# HELP nftgateway_responses_per_time_by_status_total total of responses by status per response time bucket
# TYPE nftgateway_responses_per_time_by_status_total histogram
nftgateway_responses_per_time_by_status_total{status="PinError",le="0.05",env="test"} 0
nftgateway_responses_per_time_by_status_total{status="Pinned",le="0.05",env="test"} 1
nftgateway_responses_per_time_by_status_total{status="Pinning",le="0.05",env="test"} 0
nftgateway_responses_per_time_by_status_total{status="PinQueued",le="0.05",env="test"} 0
nftgateway_responses_per_time_by_status_total{status="PinError",le="0.1",env="test"} 0
nftgateway_responses_per_time_by_status_total{status="Pinned",le="0.1",env="test"} 2
nftgateway_responses_per_time_by_status_total{status="Pinning",le="0.1",env="test"} 0
nftgateway_responses_per_time_by_status_total{status="PinQueued",le="0.1",env="test"} 0
(...)
```

Follow up work (will create issue):
- improve testing by spinning up API locally with Miniflare

Should use #1391 cache in check endpoint

Closes https://github.com/nftstorage/nft.storage/issues/1332