### PR TITLE
feat(docs): add how-to for minting on solana with metaplex

### DIFF
--- a/packages/website/pages/docs/how-to/meta.json
+++ b/packages/website/pages/docs/how-to/meta.json
@@ -1,5 +1,6 @@
 {
   "mint-erc-1155": "Store and mint NFTs using ERC-1155 metadata standards",
   "mint-custom-metadata": "Store and mint NFTs using custom metadata",
+  "mint-solana": "Store NFTs for Solana and mint with Metaplex",
   "retrieve": "Retrieve NFT data from IPFS"
 }

--- a/packages/website/pages/docs/how-to/meta.json
+++ b/packages/website/pages/docs/how-to/meta.json
@@ -1,6 +1,6 @@
 {
   "mint-erc-1155": "Store and mint NFTs using ERC-1155 metadata standards",
   "mint-custom-metadata": "Store and mint NFTs using custom metadata",
-  "mint-solana": "Store NFTs for Solana and mint with Metaplex",
+  "mint-solana": "Store and mint NFTs for Solana with Metaplex",
   "retrieve": "Retrieve NFT data from IPFS"
 }

--- a/packages/website/pages/docs/how-to/mint-solana.md
+++ b/packages/website/pages/docs/how-to/mint-solana.md
@@ -48,7 +48,7 @@ The on-chain metadata contains the public keys of the Solana accounts that are a
 
 The on-chain metadata also includes a `uri` field that links to a JSON document with details about the NFT, along with a few fields from the JSON metadata that are preserved on-chain, such as the `name` and `symbol`.
 
-For this guide, we're mostly going to focus on the JSON document with the off-chain metadata. The parts relating to keys and ownership will be covered in the [Candy machine configuration](#candy-machine-configuration) section below.
+For this guide, we're mostly going to focus on the JSON document with the off-chain metadata. The parts relating to keys and ownership will be covered in the [Candy Machine configuration](#candy-machine-configuration) section below.
 
 This is the basic metadata format for a very simple Metaplex NFT:
 
@@ -88,7 +88,7 @@ All NFTs that include an `image` will have at least one entry in `properties.fil
 
 Please note that this example does not show all possible metadata fields. Consult the [metadata standard][metaplex-token-standard] for the complete specification.
 
-## Using candy machine cli
+## Using Candy Machine CLI
 
 The Candy Machine CLI is a command-line tool written in TypeScript that takes images and their associated metadata and turns them into a collection of NFTs that can be minted from an on-chain Solana Candy Machine program.
 
@@ -246,7 +246,7 @@ Once you've run the `upload` command, your Candy Machine is ready to interact wi
 
 Before minting tokens, it's best to verify the upload to make sure everything can be retrieved correctly.
 
-You can use the `verify_upload` Candy Machine cli command, passing in the name of the local cache file. In the upload example we used the `-c example` flag to set the cache file name, so we'll use the same flag here:
+You can use the `verify_upload` Candy Machine CLI command, passing in the name of the local cache file. In the upload example we used the `-c example` flag to set the cache file name, so we'll use the same flag here:
 
 ```bash
 candy-machine verify_upload -e devnet -c example -k ~/.config/solana/devnet.json

--- a/packages/website/pages/docs/how-to/mint-solana.md
+++ b/packages/website/pages/docs/how-to/mint-solana.md
@@ -16,7 +16,7 @@ At the most fundamental level, an NFT on Solana is defined by the Solana Program
 
 To build feature-rich NFTs, the Solana community has developed standards on top of the basic NFT functionality provided by the Token program which allow "decorating" a token with metadata describing the token and its properties.
 
-This guide will focus on [Metaplex](https://metaplex.com), which is currently the most popular and fully featured NFT standard on Solana, enabling thousands of NFT projects. If you're using a different Solana program to mint your NFTs, the principles here will still apply, but you may need to use different tools and metadata conventions.
+This guide will focus on [Metaplex](https://metaplex.com), which is currently the most popular and fully featured NFT standard on Solana, enabling thousands of NFT projects.
 
 ## Metaplex NFT overview
 

--- a/packages/website/pages/docs/how-to/mint-solana.md
+++ b/packages/website/pages/docs/how-to/mint-solana.md
@@ -86,7 +86,7 @@ The `properties.files` array contains metadata about any files associated with t
 
 All NFTs that include an `image` will have at least one entry in `properties.files` with a `uri` that is equal to the value of the `image` field. As with the `image` field, this example shows a local file path, but this will be replaced with the URL for the uploaded image once it has been stored with NFT.Storage.
 
-Please note that this example does not show all possible metadata fields. Consult the [metadata standard][metaplex-metadata-standard] for the complete specification.
+Please note that this example does not show all possible metadata fields. Consult the [metadata standard][metaplex-token-standard] for the complete specification.
 
 ## Using candy machine cli
 

--- a/packages/website/pages/docs/how-to/mint-solana.md
+++ b/packages/website/pages/docs/how-to/mint-solana.md
@@ -2,11 +2,17 @@
 title: Mint NFTs on Solana with Metaplex
 ---
 
-TODO: intro:
+The [Solana](https://solana.com) blockchain is a high-performance, permissionless blockchain that has rapidly grown and found an enthusiastic community in the NFT space.
 
-- [ ] quick "what is solana" / "what is metaplex"
+With NFT.Storage, you can upload all the off-chain data for your Solana NFTs, including images, videos, animations, and metadata, leveraging the power of [decentralized storage][concepts-decentralized-storage] to preserve your NFT data and make it available on the web.
+
+You can even upload data for Solana NFTs without an NFT.Storage account! By using a signature from your Solana wallet, you (or your users, if you're building a platform) can make free uploads to NFT.Storage without an NFT.Storage API key.
+
+This guide will focus on [Metaplex](https://metaplex.com), which is currently the most popular and fully featured NFT standard on Solana, enabling thousands of NFT projects. If you're using a different Solana program to mint your NFTs, the principles here will still apply, but you may need to use different tools and metadata conventions.
 
 ## Preparing your metadata
+
+Metaplex NFTs consist 
 
 - [ ] Link to metadata standard docs
 - [ ] Walk through prepping folder of assets + metadata
@@ -29,3 +35,8 @@ TODO: intro:
     - [ ] link to Magic Eden
 - "i want even more nerdy details / I'm a Solana wizard"
     - [ ] link to metaplex-auth lib, explain that you can use it with any Solana program / signing key
+
+
+[concepts-decentralized-storage]: ../concepts/decentralized-storage/
+[metaplex-docs-token-standard]: https://docs.metaplex.com/token-metadata/Versions/v1.0.0/nft-standard
+

--- a/packages/website/pages/docs/how-to/mint-solana.md
+++ b/packages/website/pages/docs/how-to/mint-solana.md
@@ -1,0 +1,31 @@
+---
+title: Mint NFTs on Solana with Metaplex
+---
+
+TODO: intro:
+
+- [ ] quick "what is solana" / "what is metaplex"
+
+## Preparing your metadata
+
+- [ ] Link to metadata standard docs
+- [ ] Walk through prepping folder of assets + metadata
+
+## Using candy machine cli
+
+- [ ] Pre-reqs (solana keypair, etc)
+- [ ] How to install (link to official docs)
+- [ ] How to set `nft-storage` config option
+- [ ] How to optionally set `nftStorageKey` and why
+  - why: so you can see the uploads in your account, etc
+  - what happens if not: quick explainer about wallet sig auth
+- [ ] What to do after uploading
+  - give example of running candy-machine mint command
+  - link to official metaplex minting docs
+
+## Other options
+
+- "can't someone else do it?"
+    - [ ] link to Magic Eden
+- "i want even more nerdy details / I'm a Solana wizard"
+    - [ ] link to metaplex-auth lib, explain that you can use it with any Solana program / signing key

--- a/packages/website/pages/docs/how-to/mint-solana.md
+++ b/packages/website/pages/docs/how-to/mint-solana.md
@@ -2,23 +2,90 @@
 title: Mint NFTs on Solana with Metaplex
 ---
 
+import Callout from 'nextra-theme-docs/callout';
+
+
 The [Solana](https://solana.com) blockchain is a high-performance, permissionless blockchain that has rapidly grown and found an enthusiastic community in the NFT space.
 
 With NFT.Storage, you can upload all the off-chain data for your Solana NFTs, including images, videos, animations, and metadata, leveraging the power of [decentralized storage][concepts-decentralized-storage] to preserve your NFT data and make it available on the web.
 
+<!-- TODO: include this once https://github.com/metaplex-foundation/metaplex/pull/1757 is merged:
+
 You can even upload data for Solana NFTs without an NFT.Storage account! By using a signature from your Solana wallet, you (or your users, if you're building a platform) can make free uploads to NFT.Storage without an NFT.Storage API key.
+-->
+
+At the most fundamental level, an NFT on Solana is defined by the Solana Program Library's [Token program](https://spl.solana.com/token), which enables the creation of both fungible and non-fungible tokens on Solana. While it's possible to [create NFTs through the Token program directly](https://spl.solana.com/token#example-create-a-non-fungible-token), tokens created in this way have no associated metadata or intrinsic "meaning", and are essentially just unique identifiers.
+
+To build feature-rich NFTs, the Solana community has developed standards on top of the basic NFT functionality provided by the Token program which allow "decorating" a token with metadata describing the token and its properties.
 
 This guide will focus on [Metaplex](https://metaplex.com), which is currently the most popular and fully featured NFT standard on Solana, enabling thousands of NFT projects. If you're using a different Solana program to mint your NFTs, the principles here will still apply, but you may need to use different tools and metadata conventions.
 
+## Metaplex NFT overview
+
+Metaplex NFTs consist of a few pieces that work together to provide the complete "NFT experience".
+
+First, an SPL token account is created using the SPL Token program with a supply of one (with zero decimals or "fractional tokens"), making the token non-fungible. This new account is referred to as the "token mint" and is controlled by the token creator's Solana account.
+
+<Callout emoji="ℹ️">
+As of version 1.1 of the [Metaplex Token Standard][metaplex-token-standard], Metaplex also supports "semi-fungible" tokens that can have a supply greater than one. These are called "Fungible Assets" in the Metaplex docs. We won't be covering them in this guide, but it's good to know they're there!
+</Callout>
+
+The newly created token account is then registered with the Metaplex [Token Metadata contract](http://docs.metaplex.com/architecture/deep_dive/overview), which stores some information about the token "on-chain" in a Solana account. The information stored on chain includes the name of the token, a short symbol, some information about the token creators and royalty splits, and a URI that points to a JSON document with more metadata.
+
+The URI for the extended metadata is important, as the extended metadata contains all the information about the images and other media files associated with the NFT, as well as things like a description and whatever custom properties you might need.
+
 ## Preparing your metadata
 
-Metaplex NFTs consist 
+The [Metaplex Token Standard][metaplex-token-standard] defines the standard metadata fields for Metaplex NFTs. This includes both the on-chain and off-chain components.
 
-- [ ] Link to metadata standard docs
-- [ ] Walk through prepping folder of assets + metadata
+The on-chain metadata contains the public keys of the Solana accounts that are authorized to mint and update the NFT, as well as some infromation about whether the NFT has been sold, what collection it belongs to, and other pieces of "state" relating to the NFT.
+
+The on-chain metadata also includes a `uri` field that links to a JSON document with details about the NFT, along with a few fields from the JSON metadata that are preserved on-chain, such as the `name` and `symbol`.
+
+For this guide, we're mostly going to focus on the JSON document with the off-chain metadata. The parts relating to keys and ownership will be covered in the [Candy machine configuration](#candy-machine-configuration) section below.
+
+This is the basic metadata format for a very simple Metaplex NFT:
+
+```json
+{
+    "name": "NFT.Storage Example #0",
+    "symbol": "NFTDOT",
+    "description": "A text description of this NFT",
+    "image": "0.png",
+    "attributes": [
+        {"trait_type": "edification", "value": "100"}
+    ],
+    "properties": {
+        "creators": [
+          {"address": "N4f6zftYsuu4yT7icsjLwh4i6pB1zvvKbseHj2NmSQw", "share": 100}
+        ],
+        "files": [
+          {"uri": "0.png", "type": "image/png"}
+        ]
+    }
+}
+```
+
+The `name`, `symbol`, and `description` fields are standard descriptive properties that allow you to attach a human-readable name and text description to the NFT, along with a short token symbol.
+
+The `image` field specifies the filename of the main image for the NFT. Right now it points to a local file, `0.png`, which needs to be in the same directory as this JSON file. Once the image is uploaded to NFT.Storage, `0.png` will be replaced with a link to the uploaded file before the metadata is stored.
+
+The `attributes` array allows you to tag your NFT with various "traits", the meaning of which is entirely up to you. For example, if you're writing a game, your NFT weapons might have a "damage" `trait_type` whose `value` corresponds to the attack power of the weapon. Some art NFTs may benefit "rarity" trait to indicate how relatively unique a given NFT is compared to its collection-mates.
+
+Finally, the `properties` field is a home for any custom metadata you want to include, but it also contains two important sub-fields, `creators` and `files`. 
+
+The `creators` field lists the Solana wallet addresses of each of the NFT creators. Each entry in the `creators` array has a `share` that indicates how much of the sale price will go to each creator. The total of all `share` entries must sum to 100, so if there's a single creator, its share should always be 100.
+
+The `files` array contains metadata about any files associated with the NFT. Most importantly, each entry in the array contains a `type` field with the MIME content type of the file.
+
+All NFTs that include an `image` will have at least one entry in `properties.files` with a `uri` that is equal to the value of the `image` field. As with the `image` field, this example shows a local file path, but this will be replaced with the URL for the uploaded image once it has been stored with NFT.Storage.
+
+Please note that this example does not show all possible metadata fields. Consult the [metadata standard][metaplex-metadata-standard] for the complete specification.
 
 ## Using candy machine cli
 
+
+### Candy machine configuration
 - [ ] Pre-reqs (solana keypair, etc)
 - [ ] How to install (link to official docs)
 - [ ] How to set `nft-storage` config option
@@ -40,3 +107,4 @@ Metaplex NFTs consist
 [concepts-decentralized-storage]: ../concepts/decentralized-storage/
 [metaplex-docs-token-standard]: https://docs.metaplex.com/token-metadata/Versions/v1.0.0/nft-standard
 
+[metaplex-token-standard]: https://docs.metaplex.com/token-metadata/specification

--- a/packages/website/pages/docs/how-to/mint-solana.md
+++ b/packages/website/pages/docs/how-to/mint-solana.md
@@ -277,7 +277,7 @@ See the [Metaplex docs][cmv2-mint-tokens] for more examples, as well as a [guide
 
 If you're eager to use NFT.Storage for your Solana NFTs but are not creating a Candy Machine, there are a few options.
 
-[Magic Eden](https://www.magiceden.io) is a Solana NFT marketplace and community that offers a full-service NFT minting program called [Lanuchpad](https://blog.magiceden.io/p/magic-eden-launchpad) that can take care of all the technical issues involved in minting Solana NFTs. Since Lanchpad is integrated with NFT.Storage, you can take advantage of the [benefits of decentralized storage][concepts-decentralized-storage] without needing to write any code or learn about blockchain development.
+[Magic Eden](https://www.magiceden.io) is a Solana NFT marketplace and community that offers a full-service NFT minting program called [Launchpad](https://blog.magiceden.io/p/magic-eden-launchpad) that can take care of all the technical issues involved in minting Solana NFTs. Since Launchpad is integrated with NFT.Storage, you can take advantage of the [benefits of decentralized storage][concepts-decentralized-storage] without needing to write any code or learn about blockchain development.
 
 On the other hand, if you're a Solana developer who wants even more technical details, you can use the [metaplex-auth library][metaplex-auth-github] directly in your NFT projects instead of through the Candy Machine CLI. 
 

--- a/packages/website/pages/docs/how-to/mint-solana.md
+++ b/packages/website/pages/docs/how-to/mint-solana.md
@@ -42,7 +42,7 @@ Later you'll [use a tool called the Candy Machine CLI](#using-candy-machine-cli)
 
 Before you can configure and create a Candy Machine, you'll need to prepare some metadata that describes each NFT in the collection.
 
-The [Metaplex Token Standard][metaplex-token-standard] defines the standard metadata fields for Metaplex NFTs. This includes both the on-chain and off-chain components.
+The [Metaplex Token Standard][metaplex-token-standard] defines the standard metadata fields for Metaplex NFTs. This includes two separate metadata blobs: an on-chain metadata component, and an off-chain JSON file with extended metadata.
 
 The on-chain metadata contains the public keys of the Solana accounts that are authorized to mint and update the NFT, as well as some infromation about whether the NFT has been sold, what collection it belongs to, and other pieces of "state" relating to the NFT.
 

--- a/packages/website/pages/docs/how-to/mint-solana.md
+++ b/packages/website/pages/docs/how-to/mint-solana.md
@@ -8,9 +8,9 @@ import Callout from 'nextra-theme-docs/callout';
 
 [Solana](https://solana.com) is a high-performance, permissionless blockchain that has rapidly grown and found an enthusiastic community in the NFT space.
 
-With NFT.Storage, you can upload all the off-chain data for your Solana NFTs, including images, videos, animations, and metadata, leveraging the power of [decentralized storage][concepts-decentralized-storage] to preserve your NFT data and make it available on the web.
+With NFT.Storage, you can upload all the off-chain data for your Solana NFTs, including images, videos, animations, and metadata, leveraging the power of [decentralized storage][concepts-decentralized-storage] to preserve your NFT data and make it available on the web. NFT.Storage uses IPFS to reference data with using a universal identifier (meaning no one can argue what your NFT is of), and Filecoin to provide multi-generational, verifiable storage (with on-chain, cryptographic proofs trustlessly showing that those saying are storing your data are actually doing so, and storage designed to get cheaper as the network grows). Read more about NFT.Storage [here][why-nft-storage]!
 
-You can even upload data for Solana NFTs without an NFT.Storage account! By using a signature from your Solana wallet, you (or your users, if you're building a platform) can make free uploads to NFT.Storage without an NFT.Storage API key.
+You can upload data for Solana NFTs with or without an NFT.Storage account! By using a signature from your Solana wallet, you (or your users, if you're building a platform) can make free uploads to NFT.Storage without an NFT.Storage API key.
 
 At the most fundamental level, an NFT on Solana is defined by the Solana Program Library's [Token program](https://spl.solana.com/token), which enables the creation of both fungible and non-fungible tokens on Solana. While it's possible to [create NFTs through the Token program directly](https://spl.solana.com/token#example-create-a-non-fungible-token), tokens created in this way have no associated metadata or intrinsic "meaning" and are essentially just unique identifiers that can be owned by a Solana account.
 
@@ -50,7 +50,7 @@ The on-chain metadata also includes a `uri` field that links to a JSON document 
 
 For this guide, we're mostly going to focus on the JSON document with the off-chain metadata. The parts relating to keys and ownership will be covered in the [Candy Machine configuration](#candy-machine-configuration) section below.
 
-This is the basic metadata format for a very simple Metaplex NFT:
+This is the basic off-chain metadata format for a very simple Metaplex NFT:
 
 ```json
 {
@@ -120,7 +120,7 @@ Now you should be able to run `candy-machine --help` to see the same help output
 Throughout the rest of the guide, we'll use the `candy-machine` alias to keep the examples focused on the rest of the command line arguments. If you decide not to set up an alias, remember to replace `candy-machine` with the full `ts-node ~/metaplex/js/packages/cli/src/candy-machine-v2-cli.ts` command when running the example commands.
 </Callout>
 
-### Candy machine configuration
+### Candy Machine configuration
 
 Each Candy Machine project that you create is defined by two things. 
 
@@ -152,7 +152,7 @@ Here's a minimal configuration file that uses NFT.Storage for uploads:
 
 You'll need to replace `<YOUR WALLET ADDRESS>` with the address of your solana wallet.
 
-You can also optionally set the `nftStorageKey` field to an NFT.Storage API key, which will cause the uploads to appear in your NFT.Storage account's file listing. 
+If you want to use your personal NFT.Storage account to track and manage uploads associated with your account, you can also optionally set the `nftStorageKey` field to an NFT.Storage API key, which will cause the uploads to appear in your NFT.Storage account's file listing. You can create an API key in your Account page when you're logged in to [NFT.Storage](https://nft.storage/).
 
 If you do not provide an NFT.Storage API key, your Solana wallet key will be used to create a signature to authorize the upload, using the [metaplex-auth library][metaplex-auth-github].
 
@@ -269,7 +269,7 @@ wallet public key: N4f6zftYsuu4yT7icsjLwh4i6pB1zvvKbseHj2NmSQw
 mint_one_token finished 3R9XADK91RWESj3FZdzB2QXHchpjwcS5khdwZVoSd3petHyqt2T6MjntMxozX2meRFyaFZEsqjPxbCUjxz5eL5z9
 ```
 
-If you now check your wallet, for example in the [Solana explorer](https://explorer.solana.com), you should see the new token.
+If you now check your wallet, for example in the [Solana Explorer](https://explorer.solana.com), you should see the new token.
 
 See the [Metaplex docs][cmv2-mint-tokens] for more examples, as well as a [guide to setting up a minting website][cmv2-minting-website] so that anyone can easily mint tokens for themselves.
 
@@ -277,13 +277,13 @@ See the [Metaplex docs][cmv2-mint-tokens] for more examples, as well as a [guide
 
 If you're eager to use NFT.Storage for your Solana NFTs but are not creating a Candy Machine, there are a few options.
 
-[Magic Eden](https://www.magiceden.io) is a Solana NFT marketplace and community that offers a full-service NFT minting program called [Launchpad](https://blog.magiceden.io/p/magic-eden-launchpad) that can take care of all the technical issues involved in minting Solana NFTs. Since Launchpad is integrated with NFT.Storage, you can take advantage of the [benefits of decentralized storage][concepts-decentralized-storage] without needing to write any code or learn about blockchain development.
+[Magic Eden](https://www.magiceden.io) is a Solana NFT marketplace and community that offers a full-service NFT minting program called [Launchpad](https://blog.magiceden.io/p/magic-eden-launchpad) that can take care of all the technical issues involved in minting Solana NFTs. Since Lanchpad is integrated with NFT.Storage, you can take advantage of the [benefits of decentralized storage][concepts-decentralized-storage] without needing to write any code or learn about blockchain development.
 
 On the other hand, if you're a Solana developer who wants even more technical details, you can use the [metaplex-auth library][metaplex-auth-github] directly in your NFT projects instead of through the Candy Machine CLI. 
 
 Using `metaplex-auth`, you can build applications that allow users to upload NFT data directly from the browser using their Solana wallet, so that they never need to create an NFT.Storage account to take advantage of its benefits.
 
-
+[why-nft-storage]: ../why-nft-storage/
 [concepts-decentralized-storage]: ../concepts/decentralized-storage/
 [metaplex-docs-token-standard]: https://docs.metaplex.com/token-metadata/Versions/v1.0.0/nft-standard
 

--- a/packages/website/pages/docs/how-to/mint-solana.md
+++ b/packages/website/pages/docs/how-to/mint-solana.md
@@ -76,7 +76,7 @@ The `name`, `symbol`, and `description` fields are standard descriptive properti
 
 The `image` field specifies the filename of the main image for the NFT. Right now it points to a local file, `0.png`, which needs to be in the same directory as this JSON file. Once the image is uploaded to NFT.Storage, `0.png` will be replaced with a link to the uploaded file before the metadata is stored.
 
-The `attributes` array allows you to tag your NFT with various "traits", the meaning of which is entirely up to you. For example, if you're writing a game, your NFT weapons might have a "damage" `trait_type` whose `value` corresponds to the attack power of the weapon. Some art NFTs may benefit "rarity" trait to indicate how relatively unique a given NFT is compared to its collection-mates.
+The `attributes` array allows you to tag your NFT with various "traits", the meaning of which is entirely up to you. For example, if you're writing a game, your NFT weapons might have a "damage" `trait_type` whose `value` corresponds to the attack power of the weapon. Some art NFTs may benefit from a "rarity" trait to indicate how relatively unique a given NFT is compared to its collection-mates.
 
 Finally, the `properties` field is a home for any custom metadata you want to include, but it also contains two important sub-fields, `properties.creators` and `properties.files`. 
 

--- a/packages/website/pages/docs/how-to/mint-solana.md
+++ b/packages/website/pages/docs/how-to/mint-solana.md
@@ -14,7 +14,7 @@ With NFT.Storage, you can upload all the off-chain data for your Solana NFTs, in
 You can even upload data for Solana NFTs without an NFT.Storage account! By using a signature from your Solana wallet, you (or your users, if you're building a platform) can make free uploads to NFT.Storage without an NFT.Storage API key.
 -->
 
-At the most fundamental level, an NFT on Solana is defined by the Solana Program Library's [Token program](https://spl.solana.com/token), which enables the creation of both fungible and non-fungible tokens on Solana. While it's possible to [create NFTs through the Token program directly](https://spl.solana.com/token#example-create-a-non-fungible-token), tokens created in this way have no associated metadata or intrinsic "meaning", and are essentially just unique identifiers.
+At the most fundamental level, an NFT on Solana is defined by the Solana Program Library's [Token program](https://spl.solana.com/token), which enables the creation of both fungible and non-fungible tokens on Solana. While it's possible to [create NFTs through the Token program directly](https://spl.solana.com/token#example-create-a-non-fungible-token), tokens created in this way have no associated metadata or intrinsic "meaning", and are essentially just unique identifiers that can be owned by a Solana account.
 
 To build feature-rich NFTs, the Solana community has developed standards on top of the basic NFT functionality provided by the Token program which allow "decorating" a token with metadata describing the token and its properties.
 
@@ -72,11 +72,11 @@ The `image` field specifies the filename of the main image for the NFT. Right no
 
 The `attributes` array allows you to tag your NFT with various "traits", the meaning of which is entirely up to you. For example, if you're writing a game, your NFT weapons might have a "damage" `trait_type` whose `value` corresponds to the attack power of the weapon. Some art NFTs may benefit "rarity" trait to indicate how relatively unique a given NFT is compared to its collection-mates.
 
-Finally, the `properties` field is a home for any custom metadata you want to include, but it also contains two important sub-fields, `creators` and `files`. 
+Finally, the `properties` field is a home for any custom metadata you want to include, but it also contains two important sub-fields, `properties.creators` and `properties.files`. 
 
-The `creators` field lists the Solana wallet addresses of each of the NFT creators. Each entry in the `creators` array has a `share` that indicates how much of the sale price will go to each creator. The total of all `share` entries must sum to 100, so if there's a single creator, its share should always be 100.
+The `properties.creators` field lists the Solana wallet addresses of each of the NFT creators. Each entry in the `properties.creators` array has a `share` that indicates how much of the sale price will go to each creator. The total of all `share` entries must sum to 100, so if there's a single creator, its share should always be 100.
 
-The `files` array contains metadata about any files associated with the NFT. Most importantly, each entry in the array contains a `type` field with the MIME content type of the file.
+The `properties.files` array contains metadata about any files associated with the NFT. Most importantly, each entry in the array contains a `type` field with the MIME content type of the file.
 
 All NFTs that include an `image` will have at least one entry in `properties.files` with a `uri` that is equal to the value of the `image` field. As with the `image` field, this example shows a local file path, but this will be replaced with the URL for the uploaded image once it has been stored with NFT.Storage.
 
@@ -84,16 +84,40 @@ Please note that this example does not show all possible metadata fields. Consul
 
 ## Using candy machine cli
 
+A Candy Machine is a Solana program that ...
+
+### Pre-requisites
+
+TODO: list pre-reqs:
+
+- [ ] solana keypair (for devnet)
+- [ ] airdrop devnet SOL to new wallet
+- [ ] software needed:
+  - [ ] solana cli tools
+  - [ ] git
+  - [ ] node
+  - [ ] ts-node
+
 
 ### Candy machine configuration
-- [ ] Pre-reqs (solana keypair, etc)
+
 - [ ] How to install (link to official docs)
 - [ ] How to set `nft-storage` config option
 - [ ] How to optionally set `nftStorageKey` and why
   - why: so you can see the uploads in your account, etc
   - what happens if not: quick explainer about wallet sig auth
+
+### Uploading NFTs with Candy Machine
+
+- [ ] show upload cli command and expected output
+- [ ] show how to see new token in block explorer
+- [ ] show how to see token metadata uri and verify metadata
+
+### After uploading: next steps
+
 - [ ] What to do after uploading
   - give example of running candy-machine mint command
+  - mention candy machine UI
   - link to official metaplex minting docs
 
 ## Other options


### PR DESCRIPTION
This adds a how-to about minting on Solana using the candy machine CLI. I tried to thread the needle of not duplicating the official docs too much, especially for the pre-req section where they'll do a better job keeping the required version numbers, etc up to date.

cc @Annamarie2019, who kindly offered to do a proof-reading pass (thanks again!)
also cc @jnthnvctr for situational awareness :)

Closes #1374 