### PR TITLE
fix: link to main branch from generated client docs

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -47,7 +47,7 @@
     "build:cjs": "rollup --config rollup.config.js",
     "build:esm": "rollup --config rollup.esm.config.js",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && npx codecov",
-    "typedoc": "typedoc ./src/lib.js ./src/lib/interface.ts  --out ../../docs/client --excludeExternals --internalNamespace _",
+    "typedoc": "typedoc",
     "prepare": "npm run build"
   },
   "dependencies": {

--- a/packages/client/typedoc.json
+++ b/packages/client/typedoc.json
@@ -1,0 +1,8 @@
+{
+  "entryPoints": ["./src/lib.js", "./src/lib/interface.ts"],
+  "out": "../../docs/client",
+  "excludeExternals": true,
+  "internalNamespace": "_",
+  "gitRevision": "main",
+  "plugin": ["typedoc-plugin-mdn-links", "typedoc-plugin-missing-exports"]
+}


### PR DESCRIPTION
This sets the `gitRevision` typedoc option to `main` so that links to the source always target the main branch instead of the current git hash.

I also moved the typedoc options to a `typedoc.json` file, since they were getting kind of hard to maintain as cli args in the package.json script entry.

Closes #1299