### PR TITLE
fix: fixes local refetch issues on /files

### DIFF
--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -54,6 +54,7 @@ export default function Files({ user }) {
     (ctx) => getNfts(ctx.queryKey[1]),
     {
       enabled: !!user,
+      refetchOnWindowFocus: false,
     }
   )
 


### PR DESCRIPTION
Currently, in local development, window defocus / refocus causes /files to load again. This pr fixes that.