### PR TITLE
chore: update upload size limit copy

### DIFF
--- a/packages/website/lib/faqContent.js
+++ b/packages/website/lib/faqContent.js
@@ -48,10 +48,10 @@ const faqContent = {
   ),
   nftSizeRestrictions: (
     <p className="lh-copy white mb4">
-      NFT.Storage accepts storage requests up to <strong>31GiB</strong> in size!
-      Each upload can include a single file or a directory of files. (If you are
-      using the HTTP API, you&apos;ll need to do some manual splitting for files
-      over 100MB. See the{' '}
+      NFT.Storage accepts storage requests up to <strong>31GiB</strong> in size
+      per individual upload! Each upload can include a single file or a
+      directory of files. (If you are using the HTTP API, you&apos;ll need to do
+      some manual splitting for files over 100MB. See the{' '}
       <Link href="/api-docs">
         <a className="white">HTTP API docs</a>
       </Link>{' '}
@@ -146,13 +146,13 @@ const faqContent = {
   ),
   filesLimit: (
     <p className="lh-copy white mb4">
-      There are no limits enforced by the service, other than the 31GiB upload,
-      limit. However, if your directory is large or has a lot of files, you
-      might have some difficulty uploading it due to memory issues (especially
-      if you are uploading to the website via your browser or the directory size
-      is larger than your device&#39;s memory) or connection issues. If this is
-      the case for you, we recommend splitting up your directory into smaller
-      directories.
+      There are no limits enforced by the service, other than the size limit of
+      31GiB per individual upload. However, if your directory is large or has a
+      lot of files, you might have some difficulty uploading it due to memory
+      issues (especially if you are uploading to the website via your browser or
+      the directory size is larger than your device&#39;s memory) or connection
+      issues. If this is the case for you, we recommend splitting up your
+      directory into smaller directories.
     </p>
   ),
   unexpectedToken: (

--- a/packages/website/pages/index.js
+++ b/packages/website/pages/index.js
@@ -207,7 +207,8 @@ function About() {
               <p className="lh-copy">
                 <strong>NFT.Storage</strong> is a long-term storage service
                 designed for <strong>off-chain</strong> NFT data (like metadata,
-                images, and other assets) for up to 31GiB in size. Data is{' '}
+                images, and other assets) for up to 31GiB in size per individual
+                upload. Data is{' '}
                 <a
                   href="https://nftschool.dev/concepts/content-addressing"
                   className="black"

--- a/packages/website/pages/terms.js
+++ b/packages/website/pages/terms.js
@@ -49,10 +49,11 @@ export default function TermsOfService() {
         <p className="lh-copy">
           The Service is offered for the creation and storage of NFTs. Use of
           the Service to store other types of data is not permitted. The Service
-          accepts uploads of up to 31GiB in size. Currently, the Service does
-          not limit users with respect to the total amount of data they can
-          upload. Protocol Labs may amend this limit at its sole discretion,
-          though any such amendment will not affect data previously uploaded.
+          accepts uploads of up to 31GiB in size per individual upload.
+          Currently, the Service does not limit users with respect to the total
+          amount of data they can upload. Protocol Labs may amend this limit at
+          its sole discretion, though any such amendment will not affect data
+          previously uploaded.
         </p>
 
         <h2 className="chicagoflf">
@@ -100,20 +101,21 @@ export default function TermsOfService() {
           <HashLink id="storage-term">NFT.Storage Gateway</HashLink>
         </h2>
         <p className="lh-copy">
-          Use of the NFT.Storage Gateway (“the Gateway”) is subject to the 
-          Terms of Service of {' '}
+          Use of the NFT.Storage Gateway (“the Gateway”) is subject to the Terms
+          of Service of{' '}
           <a className="black" href="https://discuss.ipfs.io/tos">
             IPFS.io
-          </a>.
+          </a>
+          .
         </p>
         <p className="lh-copy">
-          When you access content via the Gateway, Protocol Labs may cache that 
-          content or the associated CID for performance reasons. Protocol Labs 
-          may also collect analytics data on use of the Gateway, including data 
-          on requests, gateway speeds, CIDs, and other performance data. 
-          Protocol Labs reserves all rights in and to any performance data and 
-          analytics collected in the course of providing the Gateway for optimizing
-          the Gateway user experience.
+          When you access content via the Gateway, Protocol Labs may cache that
+          content or the associated CID for performance reasons. Protocol Labs
+          may also collect analytics data on use of the Gateway, including data
+          on requests, gateway speeds, CIDs, and other performance data.
+          Protocol Labs reserves all rights in and to any performance data and
+          analytics collected in the course of providing the Gateway for
+          optimizing the Gateway user experience.
         </p>
       </div>
     </main>


### PR DESCRIPTION
- Updates copy to clarify that size limit of 31 GiB applies to individual uploads.

Closes #1421 