### PR TITLE
fix: nextra scolling inline style

### DIFF
--- a/packages/website/styles/nextra-overrides.css
+++ b/packages/website/styles/nextra-overrides.css
@@ -13,6 +13,8 @@
 
   .nextra-container aside.fixed {
     width: clamp(200px, 22rem, 30%);
+    top: 0 !important;
+    height: 100vh !important;
   }
 }
 


### PR DESCRIPTION
Removes the top offset in nextra fixed position. checked in Chrome, FF, Safari

<img width="951" alt="Screen Shot 2022-02-22 at 10 50 49 AM" src="https://user-images.githubusercontent.com/1189523/155200317-8fb853d1-2810-4c85-ad29-af395b6bfdae.png">

<img width="605" alt="Screen Shot 2022-02-22 at 10 50 56 AM" src="https://user-images.githubusercontent.com/1189523/155200316-f596a321-657f-4bce-8029-f1144104ecbd.png">
