### PR TITLE
fix: Api developer experience improvements

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,7 +7,8 @@
   "main": "dist/worker.js",
   "scripts": {
     "deploy": "wrangler publish --env production",
-    "predev": "./scripts/cli.js db --start && ./scripts/cli.js db-sql --cargo --testing --reset",
+    "reset": "./scripts/cli.js db --start && ./scripts/cli.js db-sql --cargo --testing --reset",
+    "predev": "./scripts/cli.js db --start && ./scripts/cli.js db-sql --cargo --testing",
     "dev": "miniflare --watch --debug --env ../../.env",
     "clean": "./scripts/cli.js db --clean && rm -rf docker/compose",
     "build": "scripts/cli.js build",

--- a/packages/api/scripts/cmds/db-sql.js
+++ b/packages/api/scripts/cmds/db-sql.js
@@ -36,23 +36,25 @@ export async function dbSqlCmd(opts) {
 
   const client = await getDbClient(env.DATABASE_CONNECTION)
 
+  // if resetting, run post reset commands here
   if (opts.reset) {
     await client.query(reset)
-  }
 
-  await client.query(configSql)
-  await client.query(tables)
+    await client.query(configSql)
+    await client.query(tables)
 
-  if (opts.cargo) {
-    if (opts.testing) {
-      await client.query(cargoTesting)
-    } else {
-      await client.query(fdw)
-      await client.query(cargo)
+    if (opts.cargo) {
+      if (opts.testing) {
+        await client.query(cargoTesting)
+      } else {
+        await client.query(fdw)
+        await client.query(cargo)
+      }
     }
+
+    await client.query(functions)
   }
 
-  await client.query(functions)
   await client.end()
 }
 


### PR DESCRIPTION
Updated dev experience to be more pleasant, doesn't require docker restart or database nuking when running dev

Doesn't require restarting or stopping docker, doesn't require nuking the database when stopping terminal.