### PR TITLE
fix: metrics cron

### DIFF
--- a/.github/workflows/cron-metrics.yml
+++ b/.github/workflows/cron-metrics.yml
@@ -2,7 +2,7 @@ name: Cron Metrics
 
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '*/15 * * * *'
   workflow_dispatch:
 
 jobs:
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         env: ['staging', 'production']
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/packages/cron/src/jobs/metrics.js
+++ b/packages/cron/src/jobs/metrics.js
@@ -1,9 +1,12 @@
 import settle from 'p-settle'
+import debug from 'debug'
 import {
   UPLOAD_TYPES,
   PIN_SERVICES,
   PIN_STATUSES,
 } from '../../../api/src/utils/db-client.js'
+
+const log = debug('metrics:updateMetrics')
 
 /**
  * @typedef {import('pg').Client} Client
@@ -17,7 +20,7 @@ const COUNT_UPLOADS = 'SELECT COUNT(*) AS total FROM upload WHERE type = $1'
 const COUNT_PINS =
   'SELECT COUNT(*) AS total FROM pin WHERE service = $1 AND status = $2'
 
-const SUM_CONTENT_DAG_SIZE = `SELECT SUM(c.dag_size) AS "total" FROM content c`
+const SUM_CONTENT_DAG_SIZE = 'SELECT SUM(c.dag_size) AS "total" FROM content c'
 
 const UPDATE_METRIC = `
 INSERT INTO metric (name, value, updated_at)
@@ -33,11 +36,21 @@ ON CONFLICT (name) DO UPDATE
  */
 export async function updateMetrics({ roPg, rwPg }) {
   const results = await settle([
-    updateUsersCount(roPg, rwPg),
-    updateContentRootDagSizeSum(roPg, rwPg),
-    ...UPLOAD_TYPES.map((t) => updateUploadsCount(roPg, rwPg, t)),
+    withTimeLog('updateUsersCount', () => updateUsersCount(roPg, rwPg)),
+    withTimeLog('updateContentRootDagSizeSum', () =>
+      updateContentRootDagSizeSum(roPg, rwPg)
+    ),
+    ...UPLOAD_TYPES.map((t) =>
+      withTimeLog(`updateUploadsCount[${t}]`, () =>
+        updateUploadsCount(roPg, rwPg, t)
+      )
+    ),
     ...PIN_SERVICES.map((svc) =>
-      PIN_STATUSES.map((s) => updatePinsCount(roPg, rwPg, svc, s))
+      PIN_STATUSES.map((s) =>
+        withTimeLog(`updatePinsCount[${svc}][${s}]`, () =>
+          updatePinsCount(roPg, rwPg, svc, s)
+        )
+      )
     ).flat(),
   ])
 
@@ -99,4 +112,19 @@ async function updatePinsCount(roPg, rwPg, service, status) {
     `pins_${service.toLowerCase()}_${status.toLowerCase()}_total`,
     rows[0].total,
   ])
+}
+
+/**
+ * @template T
+ * @param {string} name
+ * @param {() => Promise<T>} fn
+ * @returns {Promise<T>}
+ */
+async function withTimeLog(name, fn) {
+  const start = Date.now()
+  try {
+    return await fn()
+  } finally {
+    log(`${name} took: ${Date.now() - start}ms`)
+  }
 }

--- a/packages/cron/src/lib/utils.js
+++ b/packages/cron/src/lib/utils.js
@@ -97,5 +97,5 @@ export function getPg(env, mode = 'rw') {
       mode === 'rw' ? env.DATABASE_CONNECTION : env.RO_DATABASE_CONNECTION
   }
   if (!connectionString) throw new Error('missing Postgres connection string')
-  return new pg.Client({ connectionString })
+  return new pg.Pool({ connectionString })
 }


### PR DESCRIPTION
1. Switches to using `pg.Pool` so multiple SQL commands can be run concurrently!
1. Adds some logging to the metrics cron job to make debugging easier.
1. Increase the timeout by 5 mins!