### PR TITLE
fix: update styles of faq page

### DIFF
--- a/packages/website/pages/faq.js
+++ b/packages/website/pages/faq.js
@@ -92,10 +92,9 @@ const faqs = [
 
 const TOC = () => (
   <div className="flex flex-column pv1 mw7">
-    <h2 className="chicagoflf white">Table Of Contents</h2>
     {faqs.map((faq, index) => (
       <Link href={`/faq/#${hashify(faq.question)}`} key={`faq-item${index}`}>
-        <a className="white mv1 underline">
+        <a className="white mv2 underline">
           {faq.error ? `Why am I seeing: ${faq.error}` : faq.question}
         </a>
       </Link>

--- a/packages/website/styles/faq.css
+++ b/packages/website/styles/faq.css
@@ -1,0 +1,16 @@
+.faq-item h2 {
+  font-size: 28px;
+}
+.faq-item h2 code {
+  font-size: 24px;
+}
+
+/* 768px */
+@media screen and (min-width: 48rem) {
+  .faq-item h2 {
+    font-size: 32px;
+  }
+  .faq-item h2 code {
+    font-size: 28px;
+  }
+}

--- a/packages/website/styles/faq.css
+++ b/packages/website/styles/faq.css
@@ -1,8 +1,18 @@
 .faq-item h2 {
-  font-size: 28px;
+  font-size: 20px;
 }
 .faq-item h2 code {
-  font-size: 24px;
+  font-size: 16px;
+}
+
+/* 480px */
+@media screen and (min-width: 30rem) {
+  .faq-item h2 {
+    font-size: 28px;
+  }
+  .faq-item h2 code {
+    font-size: 24px;
+  }
 }
 
 /* 768px */

--- a/packages/website/styles/global.css
+++ b/packages/website/styles/global.css
@@ -17,6 +17,7 @@
 @import './table.css';
 @import './tabs.css';
 @import './footer.css';
+@import './faq.css';
 
 html {
   scroll-behavior: smooth;


### PR DESCRIPTION
Closes #1511 

```
Changes to FAQ page:

- Removes “Table of Contents” above the list of questions
- Increases the line height in the question list
- Decreases size of code snippets in question titles
```

### **Before: Excessively large code snippet title size** 👇

<img width="1680" alt="code-heading-before" src="https://user-images.githubusercontent.com/43380153/156244528-71068970-6a3f-4306-b913-b84bfa528bf1.png">

### **After: Reduced code snippet title size ** 👇

<img width="1680" alt="code-heading-after" src="https://user-images.githubusercontent.com/43380153/156244543-79f02e15-4e94-42ab-bce7-624b21fff343.png">

### **Before: With "Table of Contents" label and scrunched line-height of questions in TOC** 👇

<img width="1680" alt="toc-before" src="https://user-images.githubusercontent.com/43380153/156244549-19815427-a82a-42f5-ad8c-b80d6ac8690f.png">

### **After: No "Table of Contents" label and increased line-height for questions in TOC** 👇

<img width="1680" alt="toc-after" src="https://user-images.githubusercontent.com/43380153/156244547-258ddb88-3b13-458a-8a66-5dcbe71daee4.png">