### PR TITLE
fix: docs tabs breaking and other markdown issues

### DIFF
--- a/packages/website/pages/docs/how-to/retrieve.md
+++ b/packages/website/pages/docs/how-to/retrieve.md
@@ -25,9 +25,7 @@ IPFS uses a technique called [content addressing][ipfs-docs-concepts-cid] to uni
 
 A CID usually looks something like this:
 
-<code class="overflow-wrap-breakword">
-bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5wctk3xjpjwy
-</code>
+<p><code class="overflow-wrap-breakword">bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5wctk3xjpjwy</code></p>
 
 If your NFTs use [IPFS best practices][ipfs-docs-nft-best-practices], the link from the blockchain to your IPFS data will be in the form of a URI that looks like this:
 
@@ -60,7 +58,7 @@ Before you can retrieve your off-chain NFT metadata, you need to know where to f
 
 You can often find this information on NFT marketplaces and other NFT explorer sites. For example, OpenSea's `Details` view includes a link to an NFT's "Frozen" metadata that's been stored on IPFS:
 
-![Screenshot of OpenSea web ui showing a metadata link for an NFT](/images/opensea-nft-details.png).
+![Screenshot of OpenSea web ui showing a metadata link for an NFT](/images/opensea-nft-details.png)
 
 In the example above, the metadata link is <span className="overflow-wrap-breakword">https://ipfs.io/ipfs/bafkreigfvngoydofemwj5x5ioqsaqarvlprzgxinkcv3am3jpv2sysqobi</span>, which is an IPFS gateway URL that uses the public gateway at `https://ipfs.io`.
 
@@ -70,7 +68,7 @@ If your marketplace or wallet doesn't display the original metadata URI, you can
 
 Below is an example of calling the `uri()` function on a [Polygon](https://polygon.technology/) contract that conforms to [ERC-1155][erc-1155]:
 
-![Screenshot of polygonscan block explorer showing a call to the `uri` contract function](/images/block-explorer-read-token-uri.png).
+![Screenshot of polygonscan block explorer showing a call to the `uri` contract function](/images/block-explorer-read-token-uri.png)
 
 Now that you have your metadata address, you can download a copy [using an HTTP gateway](#using-ipfs-http-gateways) or [IPFS on your computer](#running-ipfs-on-your-computer).
 
@@ -137,7 +135,7 @@ The first step is to [find the IPFS address of the NFT's metadata](#finding-the-
 
 2. Download an IPFS Content Archive (CAR) using the metadata address
 
-Find the CID portion of the address you found in step 1. For example, if your NFT has the URI <code class="overflow-wrap-breakword">ipfs://bafkreigfvngoydofemwj5x5ioqsaqarvlprzgxinkcv3am3jpv2sysqobi`, you just need the `bafkreigfvngoydofemwj5x5ioqsaqarvlprzgxinkcv3am3jpv2sysqobi</code> part. See [Understanding IPFS addresses](#understanding-ipfs-addresses) for more about CIDs.
+Find the CID portion of the address you found in step 1. For example, if your NFT has the URI <code class="overflow-wrap-breakword">ipfs://bafkreigfvngoydofemwj5x5ioqsaqarvlprzgxinkcv3am3jpv2sysqobi</code>, you just need the <code class="overflow-wrap-breakword">bafkreigfvngoydofemwj5x5ioqsaqarvlprzgxinkcv3am3jpv2sysqobi</code> part. See [Understanding IPFS addresses](#understanding-ipfs-addresses) for more about CIDs.
 
 Using the CID, you can download an IPFS Content Archive file (CAR), which contains the data exactly as it was encoded for storage on IPFS and Filecoin. This is important, because the same file can produce multiple different CIDs, depending on how it was encoded when adding to IPFS. By downloading a CAR, you preserve all the original CIDs and make it possible to re-provide the data in exactly the format it was in when the NFT was minted.
 

--- a/packages/website/styles/nextra-overrides.css
+++ b/packages/website/styles/nextra-overrides.css
@@ -74,6 +74,16 @@
   border-radius: 0;
 }
 
+@media screen and (max-width: 600px) {
+  .nextra-container .tabs {
+    display: flex;
+    align-items: center;
+  }
+  .nextra-container .tabs__item {
+    font-size: 1rem;
+  }
+}
+
 .nextra-container .tabs__item.tabs__item--active {
   border: 2px solid var(--nsgray-100);
   border-bottom: 0;


### PR DESCRIPTION
@Codigo-Fuentes looks like the package badges were removed. I also can't duplicate the callout overlap/z-index problem on latest so it may no longer be an issue. Tabs and other items fixed marked below.

Partially closes #1329 

<img width="1256" alt="Screen Shot 2022-03-02 at 10 00 51 AM" src="https://user-images.githubusercontent.com/1189523/156422055-7f42720f-43c1-4f95-b558-d9fdb84b960a.png">
<img width="1259" alt="Screen Shot 2022-03-02 at 10 00 19 AM" src="https://user-images.githubusercontent.com/1189523/156422065-a75f3c5f-3203-460e-aa5b-de0a5706e7bc.png">
<img width="1257" alt="Screen Shot 2022-03-02 at 10 00 06 AM" src="https://user-images.githubusercontent.com/1189523/156422067-9f68c535-ec75-4262-9821-310a3f5e6299.png">
<img width="327" alt="Screen Shot 2022-03-02 at 9 46 37 AM" src="https://user-images.githubusercontent.com/1189523/156422072-7223d05a-005c-4c5f-aec2-47e665a0f139.png">
<img width="441" alt="Screen Shot 2022-03-02 at 9 46 25 AM" src="https://user-images.githubusercontent.com/1189523/156422076-f4bceb9e-da03-4aaf-893e-27d1dce5faba.png">

