### PR TITLE
fix: visibility issue conflict with nextra themes

### DIFF
--- a/packages/website/styles/utils.css
+++ b/packages/website/styles/utils.css
@@ -57,7 +57,7 @@
 }
 
 .hidden {
-  visibility: hidden;
+  display: none;
 }
 
 /*Screenreader Only utility*/


### PR DESCRIPTION
Utils was updated to have more tailwind style CSS, but nextra expects hidden to be a display property.