### PR TITLE
feat: gateway with dedicated cf gateway

### DIFF
--- a/packages/gateway/src/durable-objects/gateway-rate-limits.js
+++ b/packages/gateway/src/durable-objects/gateway-rate-limits.js
@@ -16,7 +16,7 @@ export class GatewayRateLimits2 {
     this.state = state
     this.id = this.state.id.name
     /** @type {RateLimitCharacteristics} */
-    this.rateLimitCharacteristics = getRateLimitingPreventionCharacteristics(
+    this.rateLimitCharacteristics = getRateLimitConfig(
       this.id
     )
 
@@ -84,7 +84,7 @@ const MINUTE = SECOND * 60
  * @param {string} gatewayUrl
  * @return {RateLimitCharacteristics}
  */
-function getRateLimitingPreventionCharacteristics(gatewayUrl) {
+function getRateLimitConfig(gatewayUrl) {
   switch (gatewayUrl) {
     case 'https://ipfs.io':
       return {

--- a/packages/gateway/src/durable-objects/gateway-rate-limits.js
+++ b/packages/gateway/src/durable-objects/gateway-rate-limits.js
@@ -11,12 +11,14 @@
  * Durable Object to keep track of gateway rating limits.
  * State: number[]
  */
-export class GatewayRateLimits1 {
+export class GatewayRateLimits2 {
   constructor(state) {
     this.state = state
     this.id = this.state.id.name
     /** @type {RateLimitCharacteristics} */
-    this.rateLimitCharacteristics = getRateLimitingCharacteristics(this.id)
+    this.rateLimitCharacteristics = getRateLimitingPreventionCharacteristics(
+      this.id
+    )
 
     // `blockConcurrencyWhile()` ensures no requests are delivered until initialization completes.
     this.state.blockConcurrencyWhile(async () => {
@@ -82,16 +84,16 @@ const MINUTE = SECOND * 60
  * @param {string} gatewayUrl
  * @return {RateLimitCharacteristics}
  */
-function getRateLimitingCharacteristics(gatewayUrl) {
+function getRateLimitingPreventionCharacteristics(gatewayUrl) {
   switch (gatewayUrl) {
     case 'https://ipfs.io':
       return {
         RATE_LIMIT_REQUESTS: Infinity,
-        RATE_LIMIT_TIMEFRAME: MINUTE,
+        RATE_LIMIT_TIMEFRAME: SECOND * 10,
       }
-    case 'https://cf-ipfs.com':
+    case 'https://cf.nftstorage.link':
       return {
-        RATE_LIMIT_REQUESTS: 16,
+        RATE_LIMIT_REQUESTS: Infinity,
         RATE_LIMIT_TIMEFRAME: SECOND * 10,
       }
     case 'https://nft-storage.mypinata.cloud/':

--- a/packages/gateway/src/index.js
+++ b/packages/gateway/src/index.js
@@ -10,7 +10,7 @@ import { metricsGet } from './metrics.js'
 export { GatewayMetrics0 } from './durable-objects/gateway-metrics.js'
 export { SummaryMetrics0 } from './durable-objects/summary-metrics.js'
 export { CidsTracker0 } from './durable-objects/cids.js'
-export { GatewayRateLimits1 } from './durable-objects/gateway-rate-limits.js'
+export { GatewayRateLimits2 } from './durable-objects/gateway-rate-limits.js'
 export { GatewayRedirectCounter0 } from './durable-objects/gateway-redirect-counter.js'
 
 import { addCorsHeaders, withCorsHeaders } from './cors.js'

--- a/packages/gateway/wrangler.toml
+++ b/packages/gateway/wrangler.toml
@@ -21,7 +21,7 @@ bindings = [
   {name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"},
   {name = "SUMMARYMETRICS", class_name = "SummaryMetrics0"},
   {name = "CIDSTRACKER", class_name = "CidsTracker0"},
-  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits1"},
+  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits2"},
   {name = "GATEWAYREDIRECTCOUNTER", class_name = "GatewayRedirectCounter0"}
 ]
 
@@ -29,11 +29,11 @@ bindings = [
 [env.production]
 # name = "gateway-nft-storage-production"
 account_id = "fffa4b4363a7e5250af8357087263b3a" # Protocol Labs CF account
-zone_id = "fc6cb51dbc2d0b9a729eae6a302a49c9"    # nft.storage zone
+zone_id = "c7795a0adce7609a95d62fec04705aff"    # nftstorage.link zone
 route = "*gateway.nft.storage/*"
 
 [env.production.vars]
-IPFS_GATEWAYS = "[\"https://ipfs.io\", \"https://cf-ipfs.com\", \"https://nft-storage.mypinata.cloud/\"]"
+IPFS_GATEWAYS = "[\"https://ipfs.io\", \"https://cf.nftstorage.link\", \"https://nft-storage.mypinata.cloud/\"]"
 GATEWAY_HOSTNAME = 'ipfs.nftstorage.link'
 DEBUG = "false"
 ENV = "production"
@@ -43,7 +43,7 @@ bindings = [
   {name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"},
   {name = "SUMMARYMETRICS", class_name = "SummaryMetrics0"},
   {name = "CIDSTRACKER", class_name = "CidsTracker0"},
-  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits1"},
+  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits2"},
   {name = "GATEWAYREDIRECTCOUNTER", class_name = "GatewayRedirectCounter0"}
 ]
 
@@ -51,11 +51,11 @@ bindings = [
 [env.staging]
 # name = "gateway-nft-storage-staging"
 account_id = "fffa4b4363a7e5250af8357087263b3a" # Protocol Labs CF account
-zone_id = "fc6cb51dbc2d0b9a729eae6a302a49c9"    # nft.storage zone
+zone_id = "c7795a0adce7609a95d62fec04705aff"    # nftstorage.link zone
 route = "*gateway-staging.nft.storage/*"
 
 [env.staging.vars]
-IPFS_GATEWAYS = "[\"https://ipfs.io\", \"https://cf-ipfs.com\", \"https://nft-storage.mypinata.cloud/\"]"
+IPFS_GATEWAYS = "[\"https://ipfs.io\", \"https://cf.nftstorage.link\", \"https://nft-storage.mypinata.cloud/\"]"
 GATEWAY_HOSTNAME = 'ipfs-staging.nftstorage.link'
 DEBUG = "true"
 ENV = "staging"
@@ -65,7 +65,7 @@ bindings = [
   {name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"},
   {name = "SUMMARYMETRICS", class_name = "SummaryMetrics0"},
   {name = "CIDSTRACKER", class_name = "CidsTracker0"},
-  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits1"},
+  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits2"},
   {name = "GATEWAYREDIRECTCOUNTER", class_name = "GatewayRedirectCounter0"}
 ]
 
@@ -84,7 +84,7 @@ bindings = [
   {name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"},
   {name = "SUMMARYMETRICS", class_name = "SummaryMetrics0"},
   {name = "CIDSTRACKER", class_name = "CidsTracker0"},
-  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits1"},
+  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits2"},
   {name = "GATEWAYREDIRECTCOUNTER", class_name = "GatewayRedirectCounter0"}
 ]
 
@@ -102,7 +102,7 @@ bindings = [
   {name = "GATEWAYMETRICS", class_name = "GatewayMetrics0"},
   {name = "SUMMARYMETRICS", class_name = "SummaryMetrics0"},
   {name = "CIDSTRACKER", class_name = "CidsTracker0"},
-  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits1"},
+  {name = "GATEWAYRATELIMITS", class_name = "GatewayRateLimits2"},
   {name = "GATEWAYREDIRECTCOUNTER", class_name = "GatewayRedirectCounter0"}
 ]
 
@@ -113,4 +113,9 @@ new_classes = ["GatewayMetrics0", "SummaryMetrics0", "CidsTracker0", "GatewayRat
 tag = "v2" # Should be unique for each entry
 renamed_classes = [
   {from="GatewayRateLimits0", to="GatewayRateLimits1"}
+]
+[[migrations]]
+tag = "v3" # Should be unique for each entry
+renamed_classes = [
+  {from="GatewayRateLimits1", to="GatewayRateLimits2"}
 ]


### PR DESCRIPTION
This PR adds our dedicated CF gateway as the gateway to be used 🎉 

I had our dedicated CF gateway `cf.nftstorage.link` setup with Cloudflare team, this will be an offering from them in the future and we had a manual process with them to have the DNS setup and proxying to ipfs.cloudflare.com.

With this dedicated gateway we have more freedom and powers with custom rate limits. With this in mind, a set of rules were put in place to avoid abuse and hammering this domain:
- [Firewall rule](https://dash.cloudflare.com/fffa4b4363a7e5250af8357087263b3a/nftstorage.link/firewall/firewall-rules) blocking all traffic matching `cf.nftstorage.link/*` from the outside world (only our worker can access it, same CF zone ID)
- [Rate limit rule](https://dash.cloudflare.com/fffa4b4363a7e5250af8357087263b3a/nftstorage.link/firewall/custom-rules) limiting traffic fo `cf.nftstorage.link/*` per `X-Forwarded-For`
  - wondering if we should use `cf-connecting-ip` instead, given clients can easily manipulate `X-Forwarded-For` to add fake proxies just to circumvent limits. If so, we will need to add a new header to the request to the gateways to use it. Thoughts?

Closes https://github.com/nftstorage/nft.storage/issues/1195