### PR TITLE
fix: metrics cron permissions and increase timeout

### DIFF
--- a/.github/workflows/cron-metrics.yml
+++ b/.github/workflows/cron-metrics.yml
@@ -2,7 +2,7 @@ name: Cron Metrics
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '*/20 * * * *'
   workflow_dispatch:
 
 jobs:
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         env: ['staging', 'production']
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/packages/api/db/tables.sql
+++ b/packages/api/db/tables.sql
@@ -125,6 +125,8 @@ CREATE TABLE IF NOT EXISTS content
 
 CREATE INDEX IF NOT EXISTS content_updated_at_idx ON content (updated_at);
 CREATE INDEX IF NOT EXISTS content_inserted_at_idx ON content (inserted_at);
+CREATE UNIQUE INDEX content_cid_with_size_idx ON content (cid) INCLUDE (dag_size);
+
 
 -- Information for piece of content pinned in IPFS.
 CREATE TABLE IF NOT EXISTS pin

--- a/packages/api/docker/postgres/00-initial-schema.sql
+++ b/packages/api/docker/postgres/00-initial-schema.sql
@@ -25,7 +25,7 @@ create schema if not exists cargo;
 
 -- Grant privileges
 grant usage                     on schema public, cargo to postgres, anon, authenticated, service_role;
-alter default privileges in schema public, cargo grant all on tables to postgres, anon, authenticated, service_role, stats;
+alter default privileges in schema public, cargo grant all on tables to postgres, anon, authenticated, service_role;
 alter default privileges in schema public, cargo grant all on functions to postgres, anon, authenticated, service_role;
 alter default privileges in schema public, cargo grant all on sequences to postgres, anon, authenticated, service_role;
 

--- a/packages/api/docker/postgres/00-initial-schema.sql
+++ b/packages/api/docker/postgres/00-initial-schema.sql
@@ -25,7 +25,7 @@ create schema if not exists cargo;
 
 -- Grant privileges
 grant usage                     on schema public, cargo to postgres, anon, authenticated, service_role;
-alter default privileges in schema public, cargo grant all on tables to postgres, anon, authenticated, service_role;
+alter default privileges in schema public, cargo grant all on tables to postgres, anon, authenticated, service_role, stats;
 alter default privileges in schema public, cargo grant all on functions to postgres, anon, authenticated, service_role;
 alter default privileges in schema public, cargo grant all on sequences to postgres, anon, authenticated, service_role;
 


### PR DESCRIPTION
With https://github.com/nftstorage/nft.storage/pull/1400 in and new metrics being calculated, there were a few of new issues:
- `stats` user did not have access to cargo schema https://github.com/nftstorage/nft.storage/runs/5460080791?check_suite_focus=true#step:5:119
- timeout is not likely enough https://github.com/nftstorage/nft.storage/runs/5462071587?check_suite_focus=true#step:5:90
- sum content dag size is the clear bottleneck (should have an index like we have in web3s)

The queries taking longer are:

```
2022-03-08T09:36:15.852Z metrics:updateMetrics updateTotalUploadPast7 took: 827061ms
```
and `updateContentRootDagSizeSum` which is the long lasting one

Question: Should we consider `inserted_at` idx for upload considering the execution time of `updateTotalUploadPast7`?