### PR TITLE
perf: metrics max concurrent queries and adds inserted at index to upload

### DIFF
--- a/packages/api/db/tables.sql
+++ b/packages/api/db/tables.sql
@@ -179,6 +179,8 @@ CREATE TABLE IF NOT EXISTS upload
     UNIQUE (user_id, source_cid)
 );
 
+CREATE INDEX IF NOT EXISTS upload_inserted_at_idx ON upload (inserted_at);
+
 CREATE VIEW admin_search as
 select
   u.id::text as user_id,

--- a/packages/cron/src/lib/utils.js
+++ b/packages/cron/src/lib/utils.js
@@ -90,7 +90,10 @@ export function getPg(env, mode = 'rw') {
  * @param {'ro'|'rw'} [mode]
  */
 export function getPgPool(env, mode = 'rw') {
-  return new pg.Pool({ connectionString: getPgConnString(env, mode) })
+  return new pg.Pool({
+    connectionString: getPgConnString(env, mode),
+    max: MAX_CONCURRENT_QUERIES,
+  })
 }
 
 /**
@@ -117,3 +120,5 @@ function getPgConnString(env, mode = 'rw') {
   if (!connectionString) throw new Error('missing Postgres connection string')
   return connectionString
 }
+
+export const MAX_CONCURRENT_QUERIES = 10


### PR DESCRIPTION
This PR:

- specifies max concurrent queries gathering metrics to avoid duration of some being influenced by others running in the PG pool
- adds `inserted_at` idx to upload to boost performance of metrics queries