### PR TITLE
fix: add label to docs menu to prevent double hamburger ambiguity

### DIFF
--- a/packages/website/styles/nextra-theme.css
+++ b/packages/website/styles/nextra-theme.css
@@ -1477,7 +1477,23 @@
 .nextra-container .sidebar ul > li:first-child > button {
   display: none;
 }
-
 .nextra-container .sidebar ul > li:first-child > button + div > ul {
   margin: 0;
+}
+/* add context to mobile docs hamburger */
+.nextra-container > nav .block.md\:hidden {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-gap: 1rem;
+  text-align: right;
+  font-family: var(--nstitle);
+  align-items: center;
+}
+.nextra-container > nav .block.md\:hidden svg {
+  margin: 0.5rem 0;
+}
+.nextra-container > nav .block.md\:hidden:before {
+  content: 'Table of Contents';
+  white-space: nowrap;
 }


### PR DESCRIPTION
<img width="453" alt="Screen Shot 2022-03-08 at 8 06 00 AM" src="https://user-images.githubusercontent.com/1189523/157277645-689efc31-c0fa-4ed8-b167-9c636cd802dd.png">
<img width="530" alt="Screen Shot 2022-03-07 at 10 52 20 AM" src="https://user-images.githubusercontent.com/1189523/157277655-b1d86ed2-54c4-4a4b-a148-f28c5dbac993.png">
