### PR TITLE
Fix: remove localstorage, only use magic link api for auth status

### DIFF
--- a/packages/website/components/navbar.js
+++ b/packages/website/components/navbar.js
@@ -31,7 +31,6 @@ export default function Navbar({ bgColor = 'bg-nsorange', logo, user }) {
 
   const logout = useCallback(async () => {
     await getMagic().user.logout()
-    await localStorage.removeItem('nft-user')
     await queryClient.invalidateQueries('magic-user')
     handleClearUser()
     Router.push({ pathname: '/', query: version ? { version } : null })

--- a/packages/website/components/navbar.js
+++ b/packages/website/components/navbar.js
@@ -31,7 +31,6 @@ export default function Navbar({ bgColor = 'bg-nsorange', logo, user }) {
 
   const logout = useCallback(async () => {
     await getMagic().user.logout()
-    await queryClient.invalidateQueries('magic-user')
     handleClearUser()
     Router.push({ pathname: '/', query: version ? { version } : null })
   }, [queryClient, version])

--- a/packages/website/lib/magic.js
+++ b/packages/website/lib/magic.js
@@ -49,11 +49,7 @@ export async function login(token, type = 'magic', data = {}) {
 
 export async function isLoggedIn() {
   try {
-    const meta = await getMagic().user.getMetadata()
-
-    return {
-      ...meta,
-    }
+    return await getMagic().user.getMetadata()
   } catch {
     // do nothing
   }

--- a/packages/website/lib/magic.js
+++ b/packages/website/lib/magic.js
@@ -49,17 +49,11 @@ export async function login(token, type = 'magic', data = {}) {
 
 export async function isLoggedIn() {
   try {
-    const exists = localStorage.getItem('nft-user')
-    if (exists) {
-      return JSON.parse(exists)
-    }
     const meta = await getMagic().user.getMetadata()
 
-    if (meta) {
-      localStorage.setItem('nft-user', JSON.stringify(meta))
-      return meta
+    return {
+      ...meta,
     }
-    return undefined
   } catch {
     // do nothing
   }
@@ -106,7 +100,6 @@ export async function redirectMagic() {
       const data = await login(idToken, 'email')
       return { ...data, idToken }
     } catch (err) {
-      await localStorage.removeItem('nft-user')
       await getMagic().user.logout()
       throw err
     }

--- a/packages/website/pages/_app.js
+++ b/packages/website/pages/_app.js
@@ -33,6 +33,7 @@ export default function App({ Component, pageProps }) {
       // @ts-ignore
       Sentry.setUser(user)
     }
+    // @ts-ignore
     setUser(data)
   }, [])
 


### PR DESCRIPTION
Fixes #1556, removes localstorage and _always_ calls magic link to verify user is authenticated.