### PR TITLE
fix: reapply stats format function and add loading

### DIFF
--- a/packages/website/lib/statsUtils.js
+++ b/packages/website/lib/statsUtils.js
@@ -9,6 +9,21 @@ const uploadKeysToSum = [
 ]
 
 /**
+ * Format Bytes
+ * @param {number} bytes
+ * @param {number} decimals
+ * @returns {string}
+ */
+export function formatBytes(bytes, decimals = 1) {
+  if (bytes === 0) return '0 Bytes'
+  const k = 1024
+  const dm = decimals || 1
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + sizes[i]
+}
+
+/**
  * Uploads Total
  * @param {import('./types').StatsPayload} statsObject
  * @returns {any}

--- a/packages/website/pages/stats.js
+++ b/packages/website/pages/stats.js
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react'
 import { TrustedBy } from '../components/trustedByLogos'
 import fs from 'fs'
-import decorateAdditionalCalculatedValues from '../lib/statsUtils'
+import decorateAdditionalCalculatedValues, {
+  formatBytes,
+} from '../lib/statsUtils'
 import { API } from '../lib/api'
-import bytes from 'bytes'
-import { abbreviateNumber } from 'js-abbreviation-number'
+import Loading from '../components/loading'
 
 /**
  *
@@ -44,12 +45,14 @@ export function getStaticProps() {
 export default function Stats({ logos }) {
   /** @type [any, any] */
   const [stats, setStats] = useState({})
+  const [statsLoading, setStatsLoading] = useState(false)
 
   useEffect(() => {
     fetchStats()
   }, [])
 
   async function fetchStats() {
+    setStatsLoading(true)
     try {
       const stats = await fetch(`${API}/stats`, {
         method: 'GET',
@@ -74,6 +77,7 @@ export default function Stats({ logos }) {
       }
       setStats(decorateAdditionalCalculatedValues(fakeData.data))
     }
+    // setStatsLoading(false)
   }
 
   const Marquee = () => {
@@ -114,7 +118,8 @@ export default function Stats({ logos }) {
                 <div className="pv3 ph3">
                   <p className="chicagoflf">Total uploads to NFT.Storage</p>
                   <figure className="chicagoflf">
-                    {abbreviateNumber(stats.totalUploads || 0, 1)}
+                    {statsLoading && <Loading />}
+                    {formatBytes(stats.totalUploads || 0, 1)}
                   </figure>
                   <p
                     className={`chicagoflf ${
@@ -138,7 +143,8 @@ export default function Stats({ logos }) {
                     Total data stored on Filecoin from NFT.Storage
                   </p>
                   <figure className="chicagoflf">
-                    {bytes(stats.deals_size_total || 0)}
+                    {statsLoading && <Loading />}
+                    {formatBytes(stats.deals_size_total || 0, 2)}
                   </figure>
                   <p
                     className={`chicagoflf ${

--- a/packages/website/pages/stats.js
+++ b/packages/website/pages/stats.js
@@ -77,7 +77,7 @@ export default function Stats({ logos }) {
       }
       setStats(decorateAdditionalCalculatedValues(fakeData.data))
     }
-    // setStatsLoading(false)
+    setStatsLoading(false)
   }
 
   const Marquee = () => {

--- a/packages/website/styles/stats.css
+++ b/packages/website/styles/stats.css
@@ -103,6 +103,8 @@
 .stat-card img {
   width: 100%;
   border-bottom: 1px solid;
+  object-fit: cover;
+  aspect-ratio: 5/2;
 }
 
 .stat-card .stat-green {


### PR DESCRIPTION
- fixes the safari 1px white border
- normalizes the bytes format function
- adds loading spinner while data is getting fetched