### PR TITLE
fix: gateway release cf token

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -40,7 +40,7 @@ jobs:
           SENTRY_TOKEN: ${{secrets.SENTRY_TOKEN}}
           SENTRY_UPLOAD: ${{ secrets.SENTRY_UPLOAD }}
         with:
-          apiToken: ${{secrets.CF_API_TOKEN }}
+          apiToken: ${{secrets.CF_GATEWAY_TOKEN }}
           workingDirectory: 'packages/gateway'
           environment: 'staging'
   release:
@@ -73,6 +73,6 @@ jobs:
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
           SENTRY_UPLOAD: ${{ secrets.SENTRY_UPLOAD }}
         with:
-          apiToken: ${{ secrets.CF_API_TOKEN }}
+          apiToken: ${{ secrets.CF_GATEWAY_TOKEN }}
           workingDirectory: 'packages/gateway'
           environment: 'production'


### PR DESCRIPTION
So we changed Gateway zone id to be `nftstorage.link` in Cloudflare in https://github.com/nftstorage/nft.storage/pull/1546

This means we need a new API Token for it instead of using the nft.storage zone id token

Failed deploy at https://github.com/nftstorage/nft.storage/runs/5493727385?check_suite_focus=true#step:6:47