### PR TITLE
fix: upload stat isnt a byte count, but a number count

### DIFF
--- a/packages/website/pages/stats.js
+++ b/packages/website/pages/stats.js
@@ -6,6 +6,7 @@ import decorateAdditionalCalculatedValues, {
 } from '../lib/statsUtils'
 import { API } from '../lib/api'
 import Loading from '../components/loading'
+import { abbreviateNumber } from 'js-abbreviation-number'
 
 /**
  *
@@ -119,7 +120,7 @@ export default function Stats({ logos }) {
                   <p className="chicagoflf">Total uploads to NFT.Storage</p>
                   <figure className="chicagoflf">
                     {statsLoading && <Loading />}
-                    {formatBytes(stats.totalUploads || 0, 1)}
+                    {abbreviateNumber(stats.totalUploads || 0, 1)}
                   </figure>
                   <p
                     className={`chicagoflf ${


### PR DESCRIPTION
Upload stat was formatted as bytes, but it's a total count not a byte count, so MB should be M for millions.