### PR TITLE
fix: pin by source CID

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,7 +22,7 @@
     "@ipld/car": "^3.1.20",
     "@ipld/dag-cbor": "^6.0.13",
     "@magic-sdk/admin": "^1.3.0",
-    "@nftstorage/ipfs-cluster": "^3.4.3",
+    "@nftstorage/ipfs-cluster": "^4.0.0",
     "@supabase/postgrest-js": "^0.34.1",
     "ipfs-car": "^0.6.1",
     "merge-options": "^3.0.4",

--- a/packages/api/src/routes/pins-add.js
+++ b/packages/api/src/routes/pins-add.js
@@ -32,7 +32,6 @@ export async function pinsAdd(event, ctx) {
       { status: 400 }
     )
   }
-  let meta
 
   // validate meta
   if (pinData.meta) {
@@ -42,15 +41,13 @@ export async function pinsAdd(event, ctx) {
         { status: 400 }
       )
     }
-    meta = Object.fromEntries(
+    pinData.meta = Object.fromEntries(
       Object.entries(pinData.meta).filter(([, v]) => typeof v === 'string')
     )
   }
 
-  await cluster.pin(cid.contentCid, {
+  await cluster.pin(cid.sourceCid, {
     origins: pinData.origins,
-    name: pinData.name,
-    metadata: pinData.meta,
   })
 
   const upload = await db.createUpload({

--- a/packages/api/src/routes/pins-replace.js
+++ b/packages/api/src/routes/pins-replace.js
@@ -54,7 +54,6 @@ export async function pinsReplace(event, ctx) {
       { status: 400 }
     )
   }
-  let meta
 
   // validate meta
   if (pinData.meta) {
@@ -64,15 +63,13 @@ export async function pinsReplace(event, ctx) {
         { status: 400 }
       )
     }
-    meta = Object.fromEntries(
+    pinData.meta = Object.fromEntries(
       Object.entries(pinData.meta).filter(([, v]) => typeof v === 'string')
     )
   }
 
-  await cluster.pin(cid.contentCid, {
+  await cluster.pin(cid.sourceCid, {
     origins: pinData.origins,
-    name: pinData.name,
-    metadata: pinData.meta,
   })
 
   const upload = await db.createUpload({

--- a/packages/api/src/utils/router.js
+++ b/packages/api/src/utils/router.js
@@ -1,5 +1,5 @@
 import { parse } from 'regexparam'
-import { database } from '../constants.js'
+import { database, cluster } from '../constants.js'
 
 /**
  * @typedef {{ params: Record<string, string> }} BasicRouteContext
@@ -182,7 +182,7 @@ class Router {
   listen(event) {
     const url = new URL(event.request.url)
     // Add more if needed for other backends
-    const passThrough = [database.url]
+    const passThrough = [database.url, cluster.apiUrl]
 
     // Ignore http requests from the passthrough list above
     if (!passThrough.includes(`${url.protocol}//${url.host}`)) {

--- a/packages/api/test/scripts/helpers.js
+++ b/packages/api/test/scripts/helpers.js
@@ -1,7 +1,16 @@
+import { Cluster } from '@nftstorage/ipfs-cluster'
 import { signJWT } from '../../src/utils/jwt.js'
-import { SALT } from './worker-globals.js'
+import {
+  SALT,
+  CLUSTER_API_URL,
+  CLUSTER_BASIC_AUTH_TOKEN,
+} from './worker-globals.js'
 import { PostgrestClient } from '@supabase/postgrest-js'
 import { DBClient } from '../../src/utils/db-client.js'
+
+export const cluster = new Cluster(CLUSTER_API_URL, {
+  headers: { Authorization: `Basic ${CLUSTER_BASIC_AUTH_TOKEN}` },
+})
 
 export const rawClient = new PostgrestClient(DATABASE_URL, {
   headers: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2939,6 +2939,11 @@
   resolved "https://registry.yarnpkg.com/@nftstorage/ipfs-cluster/-/ipfs-cluster-3.4.3.tgz#d29566d062cab187e26694ff337d105e8c2d3228"
   integrity sha512-SgqXQFpeOy+cR0NCxaNKuXTfCG2j+xGmzEgHDwsQZv/kriHZQPPPUJ8crekKR/Y8IZS59GUmz+vJ+CGQnmoHMg==
 
+"@nftstorage/ipfs-cluster@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@nftstorage/ipfs-cluster/-/ipfs-cluster-4.0.0.tgz#245a0cb733050c5b0d3811cee69ad4040cf38672"
+  integrity sha512-PEt85HJdXpmQ8PULbC7iDdtf12KrM9tblR+o/2k+/0pvcpAdrplJeTQkUiEGRBiyeevjFXvyMs0f/eGpfxBBgA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"


### PR DESCRIPTION
We need to pin by source CID to be consistent with all other uploads.

...also a fix to ensure the pin metadata is filtered correctly.

refs https://github.com/nftstorage/nft.storage/issues/1490

Part 2 is to pin all v0 source CIDs.