### PR TITLE
feat: add time format function/util

### DIFF
--- a/packages/website/lib/format.js
+++ b/packages/website/lib/format.js
@@ -1,0 +1,14 @@
+/**
+ * If it's a different day, it returns the day, otherwise it returns the hour
+ * @param {*} timestamp
+ * @returns {string}
+ */
+export function formatTimestamp(timestamp) {
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  })
+}

--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -5,6 +5,7 @@ import Button from '../components/button.js'
 import Tooltip from '../components/tooltip.js'
 import Loading from '../components/loading'
 import { MOCK_FILES } from '../lib/mock_files'
+import { formatTimestamp } from '../lib/format'
 import { NFTStorage } from 'nft.storage'
 import Script from 'next/script'
 import { When } from 'react-if'
@@ -193,7 +194,8 @@ export default function Files({ user }) {
     return (
       <tr className="bg-white bb">
         <td data-label="Date" className="nowrap" title={nft.created}>
-          {nft.created.split('T')[0]}
+          {/* {nft.created.split('T')[0]} */}
+          {formatTimestamp(nft.created)}
         </td>
         <td data-label="CID" className="nowrap">
           <CopyButton


### PR DESCRIPTION
timestamp still exists on hover, added localeDateString  formatting for local timezones. It's the exact function used on web3.storage.
<img width="317" alt="Screen Shot 2022-03-16 at 10 41 18 AM" src="https://user-images.githubusercontent.com/1189523/158653584-00bb129a-c961-47e0-a058-c3f1b97b29eb.png">
