### PR TITLE
fix: link to Getting Started

### DIFF
--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -4,7 +4,7 @@ Frontend build for the NFT.Storage website.
 
 ## Usage
 
-Make sure you already did step 1 and 2 from these [instructions](/#getting-started).
+Make sure you already did step 1 and 2 from these [instructions](/README.md#getting-started).
 
 ### Local environment configuration
 


### PR DESCRIPTION
In the Website README, this fixes the link to the Getting Started section of the README, which was previously broken. Since GitHub uses `blob` for files, we need to link to the file (instead of the directory).