### PR TITLE
fix: action menu URLs

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -26,6 +26,7 @@
     "jest": "^27.5.1",
     "js-abbreviation-number": "^1.4.0",
     "magic-sdk": "^6.2.1",
+    "multiformats": "^9.6.4",
     "next-mdx-remote": "^4.0.0-rc.1",
     "nextra": "^2.0.0-beta.5",
     "nextra-theme-docs": "^2.0.0-beta.5",

--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -1,6 +1,7 @@
 import { API, getNfts, getToken } from '../lib/api.js'
 import { useQuery, useQueryClient } from 'react-query'
 import { VscQuestion } from 'react-icons/vsc'
+import { CID } from 'multiformats/cid'
 import Button from '../components/button.js'
 import Tooltip from '../components/tooltip.js'
 import Loading from '../components/loading'
@@ -267,7 +268,7 @@ export default function Files({ user }) {
               >
                 <div className="actions-menu">
                   <GatewayLink cid={nft.cid} type={nft.type} />
-                  <CopyGatewayLink cid={nft.cid} type={nft.type} />
+                  <CopyIpfsUrl cid={nft.cid} type={nft.type} />
                   <CopyCID cid={nft.cid} type={nft.type} />
                   <form onSubmit={handleDeleteFile}>
                     <input type="hidden" name="cid" value={nft.cid} />
@@ -499,9 +500,7 @@ export default function Files({ user }) {
  * @param {{cid: string, type?: string}} props
  */
 function GatewayLink({ cid, type }) {
-  const gatewayLink = cid.startsWith('Qm')
-    ? `https://ipfs.io/ipfs/${cid}`
-    : `ipfs://${cid}`
+  const gatewayLink = `https://nftstorage.link/ipfs/${cid}`
   const href = type === 'nft' ? `${gatewayLink}/metadata.json` : gatewayLink
   const btnLabel = type === 'nft' ? 'View Metadata' : 'View URL'
   const btnTitle = type === 'nft' ? 'View Metadata JSON' : 'View URL'
@@ -513,15 +512,13 @@ function GatewayLink({ cid, type }) {
 }
 
 /**
- * Copy Gateway Link Component
+ * Copy the IPFS URL (ipfs://<cid>)
  *
  * @param {{cid: string, type?: string}} props
  */
-function CopyGatewayLink({ cid, type }) {
-  const gatewayLink = cid.startsWith('Qm')
-    ? `https://ipfs.io/ipfs/${cid}`
-    : `ipfs://${cid}`
-  const href = type === 'nft' ? `${gatewayLink}/metadata.json` : gatewayLink
+function CopyIpfsUrl({ cid, type }) {
+  const url = `ipfs://${CID.parse(cid).toV1()}`
+  const href = type === 'nft' ? `${url}/metadata.json` : url
 
   return (
     <CopyButton

--- a/yarn.lock
+++ b/yarn.lock
@@ -14266,12 +14266,7 @@ typedoc@0.22.7:
     minimatch "^3.0.4"
     shiki "^0.9.12"
 
-typescript@4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
-
-typescript@4.5.3:
+typescript@4.4.4, typescript@4.5.3:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
   integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==


### PR DESCRIPTION
1. Fixes "View URL" to use the `nftstorage.link` gateway
    * ...also to not use `ipfs://`
3. Fixes "Copy IPFS URL" to always be a `ipfs://<CID>` URL.
    * Upgrades CID to v1 (if not already) since CID used in host part of URL must be case insensitive

resolves https://github.com/nftstorage/nft.storage/issues/1617