### PR TITLE
fix: blog formatting with mdx p tag

### DIFF
--- a/packages/website/posts/2022-01-20-decentralizing-nft-storage.mdx
+++ b/packages/website/posts/2022-01-20-decentralizing-nft-storage.mdx
@@ -35,9 +35,9 @@ For the remainder of this post, we discuss how [NFT.Storage](http://NFT.Storage)
 Web3 unlocks a number of big paradigm shifts. One is around how [public goods are funded](https://fundingthecommons.io/). With cryptographic guarantees and smart economics, new mechanisms to create and sustain common goods in a decentralized manner are blossoming, expanding the potential pie of public goods outside those that rely on governments, faith in private companies, and/or the philanthropy of a few.
 
 ![image](https://user-images.githubusercontent.com/11778450/150448351-b15c498c-643e-4b3a-8491-c4cc76969300.png)
-<p style={{ textAlign: 'center', fontStyle: 'italic', marginBottom: 20, fontSize: 14 }}>
+<span style={{ display: 'block', textAlign: 'center', fontStyle: 'italic', marginBottom: 20, fontSize: 14 }}>
   A number of innovations using Web3 primitives are being explored to provide better support for funding common goods.
-</p>
+</span>
 
 In addition to NFT.Storage’s mission to store the world’s NFTs, we believe that most NFTs should be treated as public goods. One can debate whether specific NFTs should go for millions of dollars, but the debate around artistic value is independent of the public value that NFTs as a primitive can unlock, making it an ideal candidate for public goods funding. In addition, given the decreasing cost of storage (potentially [converging to $0](https://jcmit.net/disk2015.htm)), the societal return on investment for this data storage will only continue to increase. NFT.Storage plans to use these public funding mechanisms in the context of the Filecoin network, which provides provable and economically incentivized storage for any duration of time.
 
@@ -54,9 +54,7 @@ A lot of what we’ve built in NFT.Storage is an API tier that makes the process
 Since most browsers do not yet support IPFS natively, our HTTP APIs are centered around CIDs, with the client sending and receiving data that is easy to verify cryptographically. This eliminates the need for trust when using these APIs as on-boarding ramps for data onto IPFS and Filecoin.
 
 ![image](https://user-images.githubusercontent.com/11778450/150448398-f8c90d8a-66fe-415f-ac2f-23cbffa99861.png)
-<p style={{ textAlign: 'center', fontStyle: 'italic', marginBottom: 20, fontSize: 14 }}>
-   It’s easy to upload data via NFT.Storage’s API endpoint, and thanks to CIDs, also the uploaded data is verifiable!
-</p>
+<span style={{ display: 'block', textAlign: 'center', fontStyle: 'italic', marginBottom: 20, fontSize: 14 }}>It’s easy to upload data via NFT.Storage’s API endpoint, and thanks to CIDs, also the uploaded data is verifiable!</span>
 
 Further, we are seeing early adoption of IPFS in browsers (Brave, Opera Mobile, etc.) and with that adoption the need for these API services will continue to diminish (e.g., uploading data to Filecoin from the IPFS node in your browser with a click). In the meantime, our existing APIs will continue to operate, and we’ll continue to solve new problems with APIs until sufficient decentralized alternatives have matured.
 


### PR DESCRIPTION
@dchoi27 mdx automatically started the paragraph before the img so adding these without a line break was effectively nesting paragraphs which is not semantic.

<img width="1849" alt="Screen Shot 2022-03-21 at 11 44 48 AM" src="https://user-images.githubusercontent.com/1189523/159342728-ba08aee6-4a29-470a-ad15-68541629c4d3.png">
<img width="1872" alt="Screen Shot 2022-03-21 at 11 44 33 AM" src="https://user-images.githubusercontent.com/1189523/159342742-6c253779-f9e9-4d3f-92eb-1fb7c91340e9.png">
