### PR TITLE
fix: swap stats image, img already exists in assets folder

### DIFF
--- a/packages/website/pages/stats.js
+++ b/packages/website/pages/stats.js
@@ -138,7 +138,7 @@ export default function Stats({ logos }) {
 
             <StatCard title="Data Stored">
               <div>
-                <img src={'/images/stats-upload-count.svg'} alt="Data Stored" />
+                <img src={'/images/stats-data-stored.svg'} alt="Data Stored" />
                 <div className="pv3 ph3">
                   <p className="chicagoflf">
                     Total data stored on Filecoin from NFT.Storage


### PR DESCRIPTION
Image was already present.
<img width="1513" alt="Screen Shot 2022-03-21 at 12 04 26 PM" src="https://user-images.githubusercontent.com/1189523/159345502-192e3a31-6de7-4791-8843-0ea2f28149cf.png">
