### PR TITLE
Replace 'website' action with website_pr and website_cd

### DIFF
--- a/.github/workflows/website_cd.yml
+++ b/.github/workflows/website_cd.yml
@@ -1,11 +1,6 @@
-name: Website
+name: Website Delivery
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'packages/website/**'
-  pull_request:
     branches:
       - main
     paths:

--- a/.github/workflows/website_pr.yml
+++ b/.github/workflows/website_pr.yml
@@ -1,0 +1,16 @@
+name: Website PRs
+on:
+  pull_request:
+    paths:
+      - 'packages/website/**'
+jobs:
+  check:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - uses: bahmutov/npm-install@v1
+      - run: yarn test:website


### PR DESCRIPTION
Motivation: https://github.com/nftstorage/nft.storage/issues/1242

* Get rid of old 'website.yml' gh action that would run both on PRs to main and push to main
* Add website_pr.yml action
  * runs tests on all PRs modifying website, not just those into main branch
* Add website_cd.yml (continuous delivery)
  * runs tests - seems worth the time-cost to re-test before release
  * runs release-please - my understanding is that this action creates a PR from main -> release branch (so it's fine to never run it on PRs)
 