### PR TITLE
ci: add .github/workflows/conventional-commits.yml

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,17 @@
+name: 'Check Conventional Commits'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Motivation:
* robot-enforcement of [policy](https://filecoinproject.slack.com/archives/C02BZPRS9HP/p1648067416521459?thread_ts=1648065445.982479&cid=C02BZPRS9HP)

Changes
* Add a github action to enforce that PR titles follow conventional commits (so that squash merges of PRs dont lead to commit messages violating [this policy](https://github.com/nftstorage/nft.storage#how-should-i-write-my-commits))