### PR TITLE
fix(docs): add pre-built bundle info to troubleshooting & update faq

### DIFF
--- a/packages/website/lib/faqContent.js
+++ b/packages/website/lib/faqContent.js
@@ -233,19 +233,16 @@ const faqContent = {
   ),
   webpack4: (
     <p className="lh-copy white mb4">
-      We are working on a long-term solution but for now, you can import the
-      prebuilt bundle directly in the browser from{' '}
-      <InlineCode>
-        https://cdn.jsdelivr.net/npm/nft.storage@v5.1.3/dist/bundle.esm.min.js
-      </InlineCode>
-      <br />
-      You may also see this error in relation to the issue:
-      <br />
-      <InlineCode>
-        Uncaught SyntaxError: The requested module
-        &quot;/-/ipfs-core-utils@v0.10.5-qUdqS0pJ7xHVq6EQnGSz/dist=es2019,mode=imports/unoptimized/src/files/normalise-input/index.js&quot;
-        does not provide an export named &quot;normaliseInput&quot;
-      </InlineCode>
+      NFT.Storage is packaged in a way that causes issues with Webpack 4 and
+      other JavaScript build tools that have not been updated to support the{' '}
+      <InlineCode>exports</InlineCode> field in{' '}
+      <InlineCode>package.json</InlineCode>. If you are unable to change your
+      build tooling, you can import a pre-bundled version of the NFT.Storage
+      library by changing your import statment. Please see the{' '}
+      <a href="/docs/troubleshooting/#why-am-i-seeing-module-not-found-errors">
+        troubleshooting entry
+      </a>{' '}
+      for an example.
     </p>
   ),
 }

--- a/packages/website/pages/docs/troubleshooting.md
+++ b/packages/website/pages/docs/troubleshooting.md
@@ -6,7 +6,6 @@ title: Troubleshooting
 
 # Troubleshooting
 
-
 ### I tried using an HTTP gateway to retrieve my content from IPFS but am receiving an HTTP error. Does this mean my content was not stored successfully on NFT.Storage?
 
 Not necessarily! HTTP gateways are a great way for users who aren't running their own IPFS nodes to retrieve content from the IPFS network. 
@@ -14,6 +13,28 @@ Not necessarily! HTTP gateways are a great way for users who aren't running thei
 However, they do introduce a centralized point of failure to a user flow. If a given gateway is down, or is under too much load, or is facing other issues, users who are accessing content through that gateway might be unable to access content. In this case, we recommend trying another gateway or running and using your own IPFS node.
 
 Additionally, if the data was not stored on NFT.Storage, then there might be issues with the IPFS node(s) with a copy of the data providing that data to the gateway. Using NFT.Storage makes sure that the content stored is broadcasted to the network using best practices!
+
+### Why am I seeing "Module not found" errors?
+
+The `nft.storage` package uses the [`exports` field](https://nodejs.org/api/packages.html#packages_exports) in it's `package.json` file to export the correct code depending on the target environment. This allows us to support browsers, node.js with CommonJS (`require` syntax), and node.js with ES Modules (`import` syntax) from the same code base.
+
+Unfortunately, not all bundlers and build tools in the JS ecosystem support the `exports` field. In particular, trying to import the `nft.storage` package from a project using Webpack 4 will result in an error like this:
+
+```
+Failed to compile.
+
+./node_modules/nft.storage/src/platform.web.js
+Module not found: Can't resolve 'ipfs-car/blockstore/memory' in '/workspace/Unstoppable-Stream/node_modules/nft.storage/src'
+```
+
+If possible, upgrading your project to use Webpack 5 or adopting an alternative bundler like [Vite](https://vitejs.dev/) should fix the issue. If your project was built using an older version of [create-react-app](https://create-react-app.dev/) and has not been "ejected" to use a custom configuration, you should be able to update to the latest `react-scripts` dependency by following [the update documentation](https://create-react-app.dev/docs/updating-to-new-releases/).
+
+If you don't want to change your build setup, you can import a pre-bundled and minified version of the package by changing the import statement:
+
+```js
+import { NFTStorage } from "nft.storage/dist/bundle.esm.min.js";
+```
+
 
 ### Why am I seeing syntax error unexpected token?
 


### PR DESCRIPTION
This adds an entry to the troubleshooting page about the "module not found" issues caused by bundlers that don't support the package.json `exports` map. 

It also updates the FAQ about webpack 4 to link to the troubleshooting page. I tried adding an example of the pre-bundled import to the FAQ page, but I couldn't figure out how to quote the statement so that `faqContent.js` didn't try to treat it as an actual import and complain that it couldn't find the package.

Closes #1561 