### PR TITLE
chore: remove unused index

### DIFF
--- a/packages/api/db/tables.sql
+++ b/packages/api/db/tables.sql
@@ -144,7 +144,6 @@ CREATE TABLE IF NOT EXISTS pin
     UNIQUE (content_cid, service)
 );
 
-CREATE INDEX IF NOT EXISTS pin_updated_at_idx ON pin (updated_at);
 CREATE INDEX IF NOT EXISTS pin_composite_service_and_status_idx ON pin (service, status);
 CREATE INDEX IF NOT EXISTS pin_composite_updated_at_and_content_cid_idx ON pin (updated_at, content_cid);
 


### PR DESCRIPTION
Exists in staging but not in production DB. Removing from here to reflect production configuration (I will delete the one in staging also).