### PR TITLE
fix: lift pg statement_timeout

### DIFF
--- a/packages/api/db/config.sql
+++ b/packages/api/db/config.sql
@@ -11,6 +11,6 @@ BEGIN
   EXECUTE 'ALTER DATABASE ' || current_database() || ' SET jit = on';
   EXECUTE 'ALTER DATABASE ' || current_database() || ' SET idle_in_transaction_session_timeout = ''1min''';
   EXECUTE 'ALTER DATABASE ' || current_database() || ' SET lock_timeout = ''1min''';
-  EXECUTE 'ALTER DATABASE ' || current_database() || ' SET statement_timeout = ''30s''';
+  EXECUTE 'ALTER DATABASE ' || current_database() || ' SET statement_timeout = ''3min''';
 END
 $$;

--- a/packages/api/db/functions.sql
+++ b/packages/api/db/functions.sql
@@ -24,6 +24,7 @@ $$
 DECLARE
   inserted_upload_id BIGINT;
 BEGIN
+    SET LOCAL statement_timeout = '30s';
     insert into content (cid, dag_size, updated_at, inserted_at)
     values (data ->> 'content_cid',
             (data ->> 'dag_size')::BIGINT,


### PR DESCRIPTION
- Raises the database statement timeout to 3 minutes, this should accommodate the existing cron jobs that take ~30s to run
- Adds a localized 30s timeout to uploads
- A future improvement would be to isolate the cron jobs and postgrest users in the DB, and each user can have a statement_timeout config aligned with their actual expected times