### PR TITLE
feat: api support for ipfs-cluster@1.0

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -28,7 +28,7 @@ jobs:
           DATABASE_CONNECTION: postgresql://postgres:postgres@localhost:5432/postgres
   deploy-dev:
     name: Deploy Dev
-    if: github.event_name == 'pull_request' && github.ref != 'refs/heads/main' && secrets.CF_API_TOKEN != null
+    if: github.event_name == 'pull_request' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: test
     steps:

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -38,9 +38,11 @@ jobs:
           node-version: '16'
       - uses: bahmutov/npm-install@v1
       - name: Publish app
+        if: env.CF_API_TOKEN
         uses: cloudflare/wrangler-action@1.3.0
         env:
           SENTRY_TOKEN: ${{secrets.SENTRY_TOKEN}}
+          CF_API_TOKEN: ${{secrets.CF_API_TOKEN}}
         with:
           apiToken: ${{secrets.CF_API_TOKEN }}
           workingDirectory: 'packages/api'

--- a/packages/api/docker/docker-compose.yml
+++ b/packages/api/docker/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 
   cluster0:
     container_name: cluster0
-    image: ipfs/ipfs-cluster:latest
+    image: ipfs/ipfs-cluster:v1.0.0-rc4
     depends_on:
       - ipfs0
     environment:

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,7 +23,7 @@
     "@ipld/dag-cbor": "^6.0.13",
     "@ipld/dag-pb": "^2.1.16",
     "@magic-sdk/admin": "^1.3.0",
-    "@nftstorage/ipfs-cluster": "^4.0.0",
+    "@nftstorage/ipfs-cluster": "^5.0.1",
     "@supabase/postgrest-js": "^0.34.1",
     "ipfs-car": "^0.6.1",
     "merge-options": "^3.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2141,6 +2141,11 @@
   resolved "https://registry.yarnpkg.com/@nftstorage/ipfs-cluster/-/ipfs-cluster-4.1.0.tgz#5b76cea95774d4d17fde3a692748982d6915bce2"
   integrity sha512-Ld+dRAjEfbi5uK0Kb4zrD7fIV9W7mgx+wo4sjNhsuSe56qz4cOvP7tkMJLcqJ8KeQq7olffwYwtlZxGb0Svt/g==
 
+"@nftstorage/ipfs-cluster@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@nftstorage/ipfs-cluster/-/ipfs-cluster-5.0.1.tgz#28655fd1bd35ac145b0acdd045f7db242713b3f4"
+  integrity sha512-e5+ICMllFgMRWIojh00vk/nk6SshDKQK/LDslg2249lHuBLEeIEajxiI8eM+9+w6DO14+o12IRjhtVIRk5rRaw==
+
 "@noble/ed25519@^1.5.2":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.6.0.tgz#b55f7c9e532b478bf1d7c4f609e1f3a37850b583"
@@ -13942,7 +13947,12 @@ typedoc@^0.22.14:
     minimatch "^5.0.1"
     shiki "^0.10.1"
 
-typescript@4.4.4, typescript@4.5.3:
+typescript@4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+
+typescript@4.5.3:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
   integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==


### PR DESCRIPTION
The IPFS Cluster v1 release has much improved perf, and some breaking API changes.

In this PR we upgrade the ipfs-cluster client and local test environment to work with the v1 cluster API.

CI was [failing for the API](https://github.com/nftstorage/nft.storage/actions/runs/2115915629), so this PR includes a change to that workflow to fix that.

After merging this PR 
- Update staging env cloudflare worker secrets for CLUSTER_SERVICE to IpfsCluster & CLUSTER_BASIC_AUTH_TOKEN from 1pass - to use the new staging cluster running ipfs-cluster@1.0.0-rc.4
- open a follow PR to update the cron package dep on ipfs-cluster client.

see: https://github.com/nftstorage/nft.storage/issues/1736
see: https://github.com/nftstorage/ipfs-cluster/releases/tag/v5.0.0

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>