### PR TITLE
ci(api): fix syntax of api workflow

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -28,7 +28,7 @@ jobs:
           DATABASE_CONNECTION: postgresql://postgres:postgres@localhost:5432/postgres
   deploy-dev:
     name: Deploy Dev
-    if: github.event_name == 'pull_request' && github.ref != 'refs/heads/main' && secrets.CF_API_TOKEN != null
+    if: github.event_name == 'pull_request' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: test
     steps:


### PR DESCRIPTION
Motivation:
* api workflow isn't working isn't using valid syntax because I tried to include a secrets check in 'if' without testing (SORRY)
* https://github.com/nftstorage/nft.storage/pull/1789#issuecomment-1092972415
* https://github.com/nftstorage/nft.storage/pull/1698#pullrequestreview-936618267

Known Issues
* this is worth landing alone, but the api workflow will fail on forks that dont have that secret set. This other #1791 tries to tackle that