### PR TITLE
fix: update data-stored image path

### DIFF
--- a/packages/website/pages/stats.js
+++ b/packages/website/pages/stats.js
@@ -142,7 +142,7 @@ export default function Stats({ logos }) {
             <StatCard title="Data Stored">
               <div>
                 <Img
-                  src={'/images/stats-upload-count.svg'}
+                  src={'/images/stats-data-stored.svg'}
                   alt="Data Stored"
                   width="500px"
                   height="200px"


### PR DESCRIPTION
Fixes #1782
This PR updates the image path for the "Data Stored" section of the `/stats` page. The image asset was already in place so only a path update was needed.