### PR TITLE
feat: update links to JS lib and api docs

### DIFF
--- a/packages/website/pages/new-file.js
+++ b/packages/website/pages/new-file.js
@@ -175,12 +175,14 @@ export default function NewFile() {
             <div>
               <p className="lh-copy f7">
                 You can also upload files using the{' '}
-                <Link href="/#js-client-library">
+                <Link href="/docs/client/js/">
                   <a className="black">JS Client Library</a>
                 </Link>{' '}
                 or{' '}
-                <Link href="/#raw-http-request">
-                  <a className="black">Raw HTTP Requests</a>
+                <Link href="https://nft.storage/api-docs/">
+                  <a className="black" target="_blank">
+                    Raw HTTP Requests
+                  </a>
                 </Link>
               </p>
             </div>

--- a/packages/website/pages/new-file.js
+++ b/packages/website/pages/new-file.js
@@ -179,7 +179,7 @@ export default function NewFile() {
                   <a className="black">JS Client Library</a>
                 </Link>{' '}
                 or{' '}
-                <Link href="/api-docs/">
+                <Link href="https://nft.storage/api-docs/">
                   <a className="black">Raw HTTP Requests</a>
                 </Link>
               </p>

--- a/packages/website/pages/new-file.js
+++ b/packages/website/pages/new-file.js
@@ -179,10 +179,8 @@ export default function NewFile() {
                   <a className="black">JS Client Library</a>
                 </Link>{' '}
                 or{' '}
-                <Link href="https://nft.storage/api-docs/">
-                  <a className="black" target="_blank">
-                    Raw HTTP Requests
-                  </a>
+                <Link href="/api-docs/">
+                  <a className="black">Raw HTTP Requests</a>
                 </Link>
               </p>
             </div>


### PR DESCRIPTION
Fixes #1514
This PR updates links to the JS Client Library and the NFT Storage docs Raw HTTP Requests pages from the `/new-file` page. (page seen when one clicks "Upload" from the Files page) 