### PR TITLE
feat: cron update for cluster@1.0

### DIFF
--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -21,7 +21,7 @@
   "author": "Alan Shaw",
   "license": "(Apache-2.0 OR MIT)",
   "dependencies": {
-    "@nftstorage/ipfs-cluster": "^4.0.0",
+    "@nftstorage/ipfs-cluster": "^5.0.1",
     "debug": "^4.3.2",
     "dotenv": "^10.0.0",
     "form-data": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2136,11 +2136,6 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.4.tgz#a72ed44c9b1f850986a30fe36c59e01f8a79b5f3"
   integrity sha512-JtYuWzKXKLDMgE/xTcFtCm1MiCIRaAc5XYZfYX3n/ZWSI1SJS/GMm+Su0SAHJgRFavJh6U/p998YwO/iGTIgqQ==
 
-"@nftstorage/ipfs-cluster@^4.0.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@nftstorage/ipfs-cluster/-/ipfs-cluster-4.1.0.tgz#5b76cea95774d4d17fde3a692748982d6915bce2"
-  integrity sha512-Ld+dRAjEfbi5uK0Kb4zrD7fIV9W7mgx+wo4sjNhsuSe56qz4cOvP7tkMJLcqJ8KeQq7olffwYwtlZxGb0Svt/g==
-
 "@nftstorage/ipfs-cluster@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@nftstorage/ipfs-cluster/-/ipfs-cluster-5.0.1.tgz#28655fd1bd35ac145b0acdd045f7db242713b3f4"
@@ -13947,12 +13942,7 @@ typedoc@^0.22.14:
     minimatch "^5.0.1"
     shiki "^0.10.1"
 
-typescript@4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
-
-typescript@4.5.3:
+typescript@4.4.4, typescript@4.5.3:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
   integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==


### PR DESCRIPTION
Follow up of https://github.com/nftstorage/nft.storage/pull/1789 for today's migration. Should only be merged after api release #1749 