### PR TITLE
fix: enable next.js sentry plugin only if SENTRY_UPLOAD is true

### DIFF
--- a/packages/website/next.config.js
+++ b/packages/website/next.config.js
@@ -71,7 +71,7 @@ const withNextra = require('nextra')({
 const configWithDocs = withNextra({ ...nextConfig })
 
 const config =
-  env === 'dev'
+  env === 'dev' || process.env.SENTRY_UPLOAD !== 'true'
     ? configWithDocs
     : withSentryConfig(configWithDocs, {
         debug: false,


### PR DESCRIPTION
I realized just now that `yarn run build` in the website package always tries to upload to sentry, which doesn't work with the default local development `env.tpl` file we added in #1724.

The template sets `SENTRY_UPLOAD` to `false`, but that only affects our cli scripts. The current `next.config.js` always enables the sentry plugin if `env !== 'dev'`, so if you try to build locally you get:

```
npx next build
info  - Loaded env from /home/yusef/work/repos/nft.storage/packages/website/.env.local
info  - Checking validity of types  
info  - Creating an optimized production build  
Failed to compile.

Sentry CLI Plugin: Command failed: /home/yusef/work/repos/nft.storage/node_modules/@sentry/cli/sentry-cli releases new website@1.44.0-undefined+1a29aa9
error: API request failed
  caused by: sentry reported an error: Authentication credentials were not provided. (http status: 401)

Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.
Please attach the full debug log to all bug reports.


> Build failed because of webpack errors
```

This PR just adds a check to make sure `SENTRY_UPLOAD === true` before enabling the plugin. This should be set in our production environments, but perhaps @hugomrdias could verify?
