### PR TITLE
feat: update logo text and link to github

### DIFF
--- a/packages/website/components/trustedByLogos.js
+++ b/packages/website/components/trustedByLogos.js
@@ -39,7 +39,7 @@ export const TrustedBy = ({ logos }) => {
         <br />
         Request to add your logo{' '}
         <a
-          className="nsblue"
+          className="nsnavy"
           title="Request to add your logo!"
           href="https://github.com/nftstorage/nft.storage/discussions/1474"
           target="_blank"

--- a/packages/website/components/trustedByLogos.js
+++ b/packages/website/components/trustedByLogos.js
@@ -34,7 +34,18 @@ export const TrustedBy = ({ logos }) => {
           />
         ))}
       </div>
-      <p className="text-center chicagoflf">and 20,000+ other users!</p>
+      <p className="text-center chicagoflf">
+        and 30,000+ other users!
+        <br />
+        Request{' '}
+        <a
+          href="https://github.com/nftstorage/nft.storage/discussions/1474"
+          target="_blank"
+        >
+          here
+        </a>{' '}
+        to add your logo
+      </p>
     </div>
   )
 }

--- a/packages/website/components/trustedByLogos.js
+++ b/packages/website/components/trustedByLogos.js
@@ -39,8 +39,10 @@ export const TrustedBy = ({ logos }) => {
         <br />
         Request{' '}
         <a
+          title="Request to add your logo!"
           href="https://github.com/nftstorage/nft.storage/discussions/1474"
           target="_blank"
+          rel="noreferrer"
         >
           here
         </a>{' '}

--- a/packages/website/components/trustedByLogos.js
+++ b/packages/website/components/trustedByLogos.js
@@ -37,16 +37,17 @@ export const TrustedBy = ({ logos }) => {
       <p className="text-center chicagoflf">
         and 30,000+ other users!
         <br />
-        Request{' '}
+        Request to add your logo{' '}
         <a
+          className="nsblue"
           title="Request to add your logo!"
           href="https://github.com/nftstorage/nft.storage/discussions/1474"
           target="_blank"
           rel="noreferrer"
         >
           here
-        </a>{' '}
-        to add your logo
+        </a>
+        .
       </p>
     </div>
   )


### PR DESCRIPTION
Fixes #1686
This PR updates the count from 20,000 to 30,000 logo users and adds a link to the github discussion page where users may upload their own logo to be used on the site.