### PR TITLE
fix: add incidents to banner

### DIFF
--- a/packages/website/.env.development
+++ b/packages/website/.env.development
@@ -2,3 +2,4 @@ NEXT_PUBLIC_SENTRY_DSN=https://000000@0000000.ingest.sentry.io/00000
 NEXT_PUBLIC_ENV=dev
 NEXT_PUBLIC_API=http://localhost:8787
 NEXT_PUBLIC_MAGIC=<PUBLISHABLE_API_KEY>
+NEXT_PUBLIC_STATUS_PAGE_API=https://nftstorage-jroach.statuspage.io/api/v2

--- a/packages/website/components/layout.js
+++ b/packages/website/components/layout.js
@@ -16,13 +16,8 @@ const MaintenanceBanner = () => {
   )
 
   const incidents =
-    statusPageData?.incidents.filter(
-      (/** @type {{ resolved_at: string; }} */ incident) =>
-        incident.resolved_at === null ||
-        incident.resolved_at === '' ||
-        incident.resolved_at === 'null' ||
-        incident.resolved_at === 'undefined'
-    ) || []
+    (statusPageData?.incidents || []).filter(
+      (/** @type {{ resolved_at: string; }} */ incident) => !!incident.resolved_at)
 
   const scheduledMaintenances =
     statusPageData?.scheduled_maintenances.filter(

--- a/packages/website/components/layout.js
+++ b/packages/website/components/layout.js
@@ -18,7 +18,10 @@ const MaintenanceBanner = () => {
   const incidents =
     statusPageData?.incidents.filter(
       (/** @type {{ resolved_at: string; }} */ incident) =>
-        incident.resolved_at === null
+        incident.resolved_at === null ||
+        incident.resolved_at === '' ||
+        incident.resolved_at === 'null' ||
+        incident.resolved_at === 'undefined'
     ) || []
 
   const scheduledMaintenances =

--- a/packages/website/components/layout.js
+++ b/packages/website/components/layout.js
@@ -8,12 +8,19 @@ import { useQuery } from 'react-query'
 import { useUser } from '../lib/user'
 
 const MaintenanceBanner = () => {
-  let maintenanceMessage = ''
+  let bannerMessage = ''
 
   const { data: statusPageData, error: statusPageError } = useQuery(
     'get-statuspage-summary',
     () => getStatusPageSummary()
   )
+
+  const incidents =
+    statusPageData?.incidents.filter(
+      (/** @type {{ resolved_at: string; }} */ incident) =>
+        incident.resolved_at === null
+    ) || []
+
   const scheduledMaintenances =
     statusPageData?.scheduled_maintenances.filter(
       (/** @type {{ status: string; }} */ maintenance) =>
@@ -31,13 +38,15 @@ const MaintenanceBanner = () => {
   )
 
   if (scheduledMaintenances.length > 0) {
-    maintenanceMessage =
-      statusPageData.scheduled_maintenances[0].incident_updates[0].body
+    bannerMessage = scheduledMaintenances[0].incident_updates[0].body
   }
 
-  if (apiVersionData && apiVersionData.mode !== 'rw' && !maintenanceMessage) {
-    maintenanceMessage =
-      'The NFT.Storage API is currently undergoing maintenance...'
+  if (apiVersionData && apiVersionData.mode !== 'rw' && !bannerMessage) {
+    bannerMessage = 'The NFT.Storage API is currently undergoing maintenance...'
+  }
+
+  if (incidents.length > 0) {
+    bannerMessage = incidents[0].incident_updates?.[0]?.body
   }
 
   if (statusPageError) {
@@ -48,14 +57,14 @@ const MaintenanceBanner = () => {
     console.log(apiVersionError)
   }
 
-  if (maintenanceMessage) {
+  if (bannerMessage) {
     return (
       <div
         className="bg-yellow border border-solid border-black"
         style={{ zIndex: 50 }}
       >
         <div className="leading-normal max-w-7xl text-center mx-auto py-4 px-4">
-          <span className="text-xl">⚠</span> {maintenanceMessage}
+          <span className="text-xl">⚠</span> {bannerMessage}
         </div>
       </div>
     )

--- a/packages/website/components/layout.js
+++ b/packages/website/components/layout.js
@@ -15,9 +15,9 @@ const MaintenanceBanner = () => {
     () => getStatusPageSummary()
   )
 
-  const incidents =
-    (statusPageData?.incidents || []).filter(
-      (/** @type {{ resolved_at: string; }} */ incident) => !!incident.resolved_at)
+  const incidents = (statusPageData?.incidents || []).filter(
+    (/** @type {{ resolved_at: string; }} */ incident) => !incident.resolved_at
+  )
 
   const scheduledMaintenances =
     statusPageData?.scheduled_maintenances.filter(

--- a/packages/website/lib/statuspage-api.js
+++ b/packages/website/lib/statuspage-api.js
@@ -1,4 +1,5 @@
-export const API = 'https://status.nft.storage/api/v2'
+export const API =
+  process.env.NEXT_PUBLIC_STATUS_PAGE_API || 'https://status.nft.storage/api/v2'
 
 export async function getStatusPageSummary() {
   const route = '/summary.json'


### PR DESCRIPTION
Fixes #1728
This PR adds incidents notices to the NFT.storage banner. If there is an incident, it will take precedence over maintenance notices. 