### PR TITLE
chore: trigger package tests when yarn lock changes

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - 'packages/api/**'
       - '.github/workflows/api.yml'
+      - 'yarn.lock'
   pull_request:
     paths:
       - 'packages/api/**'
       - '.github/workflows/api.yml'
+      - 'yarn.lock'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'packages/client/**'
       - '.github/workflows/client.yml'
+      - 'yarn.lock'
   pull_request:
     branches:
       - main
     paths:
       - 'packages/client/**'
       - '.github/workflows/client.yml'
+      - 'yarn.lock'
 
 jobs:
   check:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -5,9 +5,11 @@ on:
       - main
     paths:
       - 'packages/website/**'
+      - 'yarn.lock'
   pull_request:
     paths:
       - 'packages/website/**'
+      - 'yarn.lock'
 
 jobs:
   check:


### PR DESCRIPTION
We already had a couple of occurrences when one package changing dependencies impacted other packages as their CI jobs did not run (api CI is currently failing due to https://github.com/nftstorage/nft.storage/pull/1701 changes from website deps).

When `yarn.lock` is changed, we should run all packages to avoid this

Needs fix from https://github.com/nftstorage/nft.storage/pull/1840