### PR TITLE
fix: remove cluster API URL from /version endpoint

### DIFF
--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -33,7 +33,6 @@ import {
   DEFAULT_MODE,
   setMaintenanceModeGetter,
 } from './middleware/maintenance.js'
-import { cluster } from './constants.js'
 import { getContext } from './utils/context.js'
 import { withAuth } from './middleware/auth.js'
 
@@ -68,7 +67,6 @@ r.add(
       commit: COMMITHASH,
       branch: BRANCH,
       mode: getMaintenanceMode(),
-      cluster: cluster.apiUrl,
     })
   },
   [postCors]


### PR DESCRIPTION
This was added for local testing but never removed.