### PR TITLE
fix: redirect to home page from files on refresh

### DIFF
--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -28,7 +28,6 @@ export function getStaticProps() {
     props: {
       title: 'Files - NFT Storage',
       navBgColor: 'bg-nsyellow',
-      redirectTo: '/',
       needsUser: true,
     },
   }

--- a/packages/website/pages/manage.js
+++ b/packages/website/pages/manage.js
@@ -19,7 +19,6 @@ export function getStaticProps() {
       title: 'Manage API Keys - NFT Storage',
       description: 'Manage your NFT.Storage account',
       navBgColor: 'bg-nsgreen',
-      redirectTo: '/',
       needsUser: true,
       altLogo: true,
     },

--- a/packages/website/pages/new-file.js
+++ b/packages/website/pages/new-file.js
@@ -18,7 +18,7 @@ export function getStaticProps() {
     props: {
       title: 'New NFT - NFT Storage',
       navBgColor: 'bg-nsyellow',
-      redirectTo: '/',
+      redirectTo: '/files',
       needsUser: true,
     },
   }

--- a/packages/website/pages/new-key.js
+++ b/packages/website/pages/new-key.js
@@ -17,7 +17,7 @@ export function getStaticProps() {
       title: 'New API Key - NFT Storage',
       navBgColor: 'bg-nsgreen',
       needsUser: true,
-      redirectTo: '/',
+      redirectTo: '/manage',
     },
   }
 }


### PR DESCRIPTION
Fixes #1726
This PR updates several static props causing redirect issues on SSR / Hard Refresh. 
- Files page no longer redirects to home page on hard-refresh
- API Keys (/manage) no longer redirects to home pages on hard-refresh
- New File an New API Keys pages, on refresh, now redirect to their respective parent pages Files and API Keys