### PR TITLE
fix: single() on multiple rows

### DIFF
--- a/packages/api/db/cargo.testing.sql
+++ b/packages/api/db/cargo.testing.sql
@@ -59,6 +59,9 @@ INSERT INTO cargo.metrics_log (name, dimensions, value, collected_at) VALUES
 INSERT INTO cargo.metrics_log (name, dimensions, value, collected_at) VALUES
   ('dagcargo_project_bytes_in_active_deals', '{{project,nft.storage}}', 169334115720738, '2022-03-01 16:33:28.505513+00');
 
+INSERT INTO cargo.metrics_log (name, dimensions, value, collected_at) VALUES
+  ('dagcargo_project_bytes_in_active_deals', '{{project,nft.storage}}', 169334115720737, '2022-02-01 16:33:28.505513+00');
+
 INSERT INTO cargo.aggregate_entries ("aggregate_cid", "cid_v1", "datamodel_selector") VALUES
 ('bafybeiek5gau46j4dxoyty27qtirb3iuoq7aax4l3xt25mfk2igyt35bme', 'bafybeiaj5yqocsg5cxsuhtvclnh4ulmrgsmnfbhbrfxrc3u2kkh35mts4e', 'Links/19/Hash/Links/46/Hash/Links/0/Hash');
 

--- a/packages/api/src/utils/db-client.js
+++ b/packages/api/src/utils/db-client.js
@@ -587,7 +587,7 @@ export class DBClient {
       })
       .lte('collected_at', weekAgo.toISOString())
       .order('collected_at', { ascending: false })
-      .range(0, 1)
+      .range(0, 0)
       .single()
 
     const [primaryRes, dagSizeRes, dagSizeHistRes] = await Promise.all([


### PR DESCRIPTION
In `.range(from, to)`, the `to` value is _inclusive_. The tests were not throwing because only one row in the fixture but in staging this breaks.

Fixtures updated to ensure multiple values are present in the DB.