### PR TITLE
fix: bump MAX_BLOCK_SIZE to 2MiB limit imposed by bitswap

### DIFF
--- a/packages/api/src/routes/nfts-upload.js
+++ b/packages/api/src/routes/nfts-upload.js
@@ -10,7 +10,7 @@ import { JSONResponse } from '../utils/json-response.js'
 import { checkAuth } from '../utils/auth.js'
 import { toNFTResponse } from '../utils/db-transforms.js'
 
-const MAX_BLOCK_SIZE = 1 << 20 // Maximum permitted block size in bytes (1MiB).
+const MAX_BLOCK_SIZE = 1 << 21 // Maximum permitted block size in bytes (2MiB).
 const decoders = [pb, raw, cbor]
 
 /**
@@ -195,7 +195,7 @@ export async function nftUpdateUpload(event, ctx) {
  *
  * - Missing root CIDs
  * - >1 root CID
- * - Any block bigger than MAX_BLOCK_SIZE (1MiB)
+ * - Any block bigger than MAX_BLOCK_SIZE (2MiB)
  * - 0 blocks
  * - Missing root block
  * - Missing non-root blocks (when root block has links)


### PR DESCRIPTION
Bitswap spec is being updated to clarify the 2MiB limit: https://github.com/ipfs/specs/pull/269

go-ipfs chunker accepts a max size of 1MiB but protobuf wrapping can make it a bit bigger. Switching to 2MiB allows us to support blocks created using that max chunker size.

refs https://github.com/web3-storage/web3.storage/pull/1269