### PR TITLE
fix: verify CIDs match data in CAR uploads

### DIFF
--- a/packages/api/src/errors.js
+++ b/packages/api/src/errors.js
@@ -139,6 +139,19 @@ export class ErrorInvalidCid extends Error {
 }
 ErrorInvalidCid.CODE = 'ERROR_INVALID_CID'
 
+export class InvalidCarError extends Error {
+  /**
+   * @param {string} reason
+   */
+  constructor(reason) {
+    super(`Invalid CAR file received: ${reason}`)
+    this.name = 'InvalidCar'
+    this.status = 400
+    this.code = InvalidCarError.CODE
+  }
+}
+InvalidCarError.CODE = 'ERROR_INVALID_CAR'
+
 export class ErrorMetaplexTokenNotFound extends Error {
   constructor(msg = 'Metaplex token not found.') {
     super(msg)

--- a/packages/api/src/routes/nfts-upload.js
+++ b/packages/api/src/routes/nfts-upload.js
@@ -1,10 +1,12 @@
 import { packToBlob } from 'ipfs-car/pack/blob'
 import { CarBlockIterator } from '@ipld/car'
+import { equals } from 'uint8arrays'
 import * as raw from 'multiformats/codecs/raw'
 import * as cbor from '@ipld/dag-cbor'
 import * as pb from '@ipld/dag-pb'
 import { Block } from 'multiformats/block'
-import { HTTPError } from '../errors.js'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { HTTPError, InvalidCarError } from '../errors.js'
 import * as cluster from '../cluster.js'
 import { JSONResponse } from '../utils/json-response.js'
 import { checkAuth } from '../utils/auth.js'
@@ -227,6 +229,14 @@ export async function carStat(carBlob, { structure } = {}) {
     const blockSize = block.bytes.byteLength
     if (blockSize > MAX_BLOCK_SIZE) {
       throw new Error(`block too big: ${blockSize} > ${MAX_BLOCK_SIZE}`)
+    }
+    if (block.cid.multihash.code === sha256.code) {
+      const ourHash = await sha256.digest(block.bytes)
+      if (!equals(ourHash.digest, block.cid.multihash.digest)) {
+        throw new InvalidCarError(
+          `block data does not match CID for ${block.cid.toString()}`
+        )
+      }
     }
     if (!rawRootBlock && block.cid.equals(rootCid)) {
       rawRootBlock = block


### PR DESCRIPTION
For sha256 hashed data we check the data in each block matches the multihash provided, to detect malformed uploads early and alert the user.

We may support other hash functions later.

A port of https://github.com/web3-storage/web3.storage/pull/1069


TODO:
- [x] check the multihashes
- [x] test

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>