### PR TITLE
feat: login by passing API token in URL #hash

### DIFF
--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -23,6 +23,7 @@ import { metaplexUpload } from './routes/metaplex-upload.js'
 import { blogSubscribe } from './routes/blog-subscribe.js'
 import { userDIDRegister } from './routes/user-did-register.js'
 import { userTags } from './routes/user-tags.js'
+import { userMetadata } from './routes/user-metadata.js'
 import { ucanToken } from './routes/ucan-token.js'
 import { did } from './routes/did.js'
 
@@ -158,6 +159,7 @@ r.add(
   [postCors]
 )
 r.add('get', '/user/tags', withAuth(withMode(userTags, RO)), [postCors])
+r.add('get', '/user/meta', withAuth(withMode(userMetadata, RO)), [postCors])
 
 // Tokens
 r.add('get', '/internal/tokens', withAuth(withMode(tokensList, RO)), [postCors])

--- a/packages/api/src/routes/user-metadata.js
+++ b/packages/api/src/routes/user-metadata.js
@@ -1,0 +1,16 @@
+import { checkAuth } from '../utils/auth.js'
+import { JSONResponse } from '../utils/json-response.js'
+
+/** @type {import('../bindings').Handler} */
+export const userMetadata = async (event, ctx) => {
+  const { user } = checkAuth(ctx)
+
+  const issuer = user.magic_link_id ?? user.did ?? user.github_id
+  const publicAddress = user.public_address
+
+  const meta = { issuer, publicAddress }
+  return new JSONResponse({
+    ok: true,
+    value: meta,
+  })
+}

--- a/packages/api/src/utils/db-client.js
+++ b/packages/api/src/utils/db-client.js
@@ -91,6 +91,7 @@ export class DBClient {
     magic_link_id,
     github_id,
     did,
+    public_address,
     keys:auth_key_user_id_fkey(user_id,id,name,secret),
     tags:user_tag_user_id_fkey(user_id,id,tag,value)
     `

--- a/packages/website/components/navbar.js
+++ b/packages/website/components/navbar.js
@@ -7,7 +7,7 @@ import Hamburger from '../icons/hamburger'
 import Link from 'next/link'
 import clsx from 'clsx'
 import countly from '../lib/countly'
-import { logoutMagicSession } from '../lib/magic.js'
+import { logoutUserSession } from '../lib/api.js'
 import { useQueryClient } from 'react-query'
 import Logo from '../components/logo'
 import { useUser } from 'lib/user.js'
@@ -30,7 +30,7 @@ export default function Navbar({ bgColor = 'bg-nsorange', logo, user }) {
   const version = /** @type {string} */ (query.version)
 
   const logout = useCallback(async () => {
-    await logoutMagicSession()
+    await logoutUserSession()
     delete sessionStorage.hasSeenUserBlockedModal
     handleClearUser()
     Router.push({ pathname: '/', query: version ? { version } : null })

--- a/packages/website/pages/_app.js
+++ b/packages/website/pages/_app.js
@@ -6,9 +6,8 @@ import Layout from '../components/layout.js'
 import { ReactQueryDevtools } from 'react-query/devtools'
 import Router, { useRouter } from 'next/router'
 import countly from '../lib/countly'
-import { getUserTags } from '../lib/api'
+import { getUserMetadata, getUserTags } from '../lib/api'
 import { useCallback, useEffect, useState } from 'react'
-import { getMagicUserMetadata } from 'lib/magic'
 import * as Sentry from '@sentry/nextjs'
 import { UserContext } from 'lib/user'
 import BlockedUploadsModal from 'components/blockedUploadsModal.js'
@@ -30,12 +29,11 @@ export default function App({ Component, pageProps }) {
     useState(false)
 
   const handleIsLoggedIn = useCallback(async () => {
-    const data = await getMagicUserMetadata()
+    const data = await getUserMetadata()
     if (!data) return
-    if (data) {
-      // @ts-ignore
-      Sentry.setUser(user)
-    }
+
+    // @ts-ignore
+    Sentry.setUser(user)
     const tags = await getUserTags()
     if (tags.HasAccountRestriction && !sessionStorage.hasSeenUserBlockedModal) {
       sessionStorage.hasSeenUserBlockedModal = true

--- a/packages/website/pages/api-docs.js
+++ b/packages/website/pages/api-docs.js
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { getMagicUserToken } from 'lib/magic'
+import { getClientRequestToken } from 'lib/api'
 import dynamic from 'next/dynamic'
 
 const DynamicSwaggerUI = dynamic(import('swagger-ui-react'), { ssr: false })
@@ -11,7 +11,7 @@ const DynamicSwaggerUI = dynamic(import('swagger-ui-react'), { ssr: false })
 const requestHandler = async (req) => {
   let token
   try {
-    token = await getMagicUserToken()
+    token = await getClientRequestToken()
     // @ts-ignore
     req.headers.Authorization = 'Bearer ' + token
   } catch (error) {}


### PR DESCRIPTION
This adds the ability to set the URL hash to `#authToken=<your-api-key>` and use it to authenticate to the API.

It adds a `/user/meta` route to return the `issuer` and `publicAddress`, which we were previously getting from `getMagic().user.getMetadata()`.

The "is logged in" check in `_app.js` was previously using `getMetadata()` to set the `user` object that gets passed through to `UserContext`. Since we can no longer assume that all logged in users will have a valid magic link session, I had to add a server route to return similar data (`issuer` and `publicAddress`).

Stores the token from the fragment in localStorage, so we can clear the fragment and keep accessing the token. Maybe sessionStorage is more appropriate? I forget when to use which, lol.

This probably needs some cleanup, and it's branched off of #1864, so it's a draft for now.

@redaphid will you play with this next week? I probably won't have time to work on it, but I can answer any questions you might have.

To use it with the test user in the local development env, follow [this link](http://localhost:4000/#authToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweDY1MDA3QTczOWFiN0FDNWM1MzcxNjEyNDliODEyNTBFNDllMjg1M0MiLCJpc3MiOiJuZnQtc3RvcmFnZSIsImlhdCI6MTYzOTc1NDczNjYzOCwibmFtZSI6Im1haW4ifQ.wKwJIRXXHsgwVp8mOQp6r3_F4Lz5lnoAkgVP8wqwA_Y) while the dev server is running from this branch (assuming it's on the default port).



