### PR TITLE
feat: add blocked API key message

### DIFF
--- a/packages/api/src/errors.js
+++ b/packages/api/src/errors.js
@@ -116,6 +116,16 @@ export class ErrorUserNotFound extends Error {
 }
 ErrorUserNotFound.CODE = 'ERROR_USER_NOT_FOUND'
 
+export class ErrorTokenIsBlocked extends Error {
+  constructor(msg = 'API Key is blocked.') {
+    super(msg)
+    this.name = 'TokenIsBlocked'
+    this.status = 403
+    this.code = ErrorTokenIsBlocked.CODE
+  }
+}
+ErrorTokenIsBlocked.CODE = 'ERROR_TOKEN_IS_BLOCKED'
+
 export class ErrorTokenNotFound extends Error {
   constructor(msg = 'API Key not found.') {
     super(msg)

--- a/packages/api/src/utils/auth.js
+++ b/packages/api/src/utils/auth.js
@@ -5,6 +5,7 @@ import {
   ErrorUserNotFound,
   ErrorTokenNotFound,
   ErrorUnauthenticated,
+  ErrorTokenIsBlocked,
 } from '../errors.js'
 import { parseJWT, verifyJWT } from './jwt.js'
 export const magic = new Magic(secrets.magic)
@@ -40,16 +41,34 @@ export async function validate(event, { log, db, ucanService }, options) {
   // validate access tokens
   if (await verifyJWT(token, secrets.salt)) {
     const decoded = parseJWT(token)
-    const user = await db.getUser(decoded.sub)
+    const user = await db.getUser(decoded.sub, { includeAllKeys: true })
 
     if (user) {
       const key = user.keys.find((k) => k?.secret === token)
       if (key) {
+        const keyHistory = await db.getAuthKeyHistory(key.id)
+        if (keyHistory?.[0]?.status === 'Blocked') {
+          throw new ErrorTokenIsBlocked()
+        }
+
+        if (!keyHistory || !keyHistory.find((kh) => kh.deleted_at === null)) {
+          throw new ErrorTokenNotFound()
+        }
+
         log.setUser({
           id: user.id,
         })
         return {
-          user: user,
+          user: {
+            ...user,
+            keys: user.keys
+              .filter((k) => k.deleted_at === null)
+              .map((k) => {
+                const newKey = { ...k }
+                delete newKey.deleted_at
+                return newKey
+              }),
+          },
           key,
           db,
           type: 'key',

--- a/packages/api/src/utils/db-client-types.ts
+++ b/packages/api/src/utils/db-client-types.ts
@@ -15,7 +15,7 @@ export type UpsertUserInput = Pick<
 
 export type UserOutputKey = Pick<
   definitions['auth_key'],
-  'user_id' | 'id' | 'name' | 'secret'
+  'user_id' | 'id' | 'name' | 'secret' | 'deleted_at'
 >
 
 export type UserOutputTag = Pick<
@@ -39,6 +39,8 @@ export type UploadOutput = definitions['upload'] & {
   }
   deals: Deal[]
 }
+
+export type AuthKeyHistoryOutput = definitions['auth_key_history']
 
 export interface CreateUploadInput {
   user_id: definitions['upload']['user_id']
@@ -88,6 +90,10 @@ export interface ListUploadsOptions {
    */
   limit?: number
   meta?: unknown
+}
+
+export interface GetUserOptions {
+  includeAllKeys: boolean
 }
 
 export type StatsPayload = {


### PR DESCRIPTION
Currently when an admin blocks an API key on admin.storage, it will both set a 'Blocked' status on the key as well as a timestamp for the key's `deleted_at` field.  NFT.storage only looks at the `deleted_at` field and thus gives a nondescript error message.  For users that authenticate via JWT, this will now also check the status of their token if it's deleted so that more information can be provided to the user.