### PR TITLE
feat: return unique error message when using a blocked key

### DIFF
--- a/packages/api/src/errors.js
+++ b/packages/api/src/errors.js
@@ -116,6 +116,16 @@ export class ErrorUserNotFound extends Error {
 }
 ErrorUserNotFound.CODE = 'ERROR_USER_NOT_FOUND'
 
+export class ErrorTokenBlocked extends Error {
+  constructor(msg = 'API Key is blocked.') {
+    super(msg)
+    this.name = 'TokenBlocked'
+    this.status = 403
+    this.code = ErrorTokenBlocked.CODE
+  }
+}
+ErrorTokenBlocked.CODE = 'ERROR_TOKEN_BLOCKED'
+
 export class ErrorTokenNotFound extends Error {
   constructor(msg = 'API Key not found.') {
     super(msg)

--- a/packages/api/src/utils/db-client-types.ts
+++ b/packages/api/src/utils/db-client-types.ts
@@ -15,7 +15,7 @@ export type UpsertUserInput = Pick<
 
 export type UserOutputKey = Pick<
   definitions['auth_key'],
-  'user_id' | 'id' | 'name' | 'secret'
+  'user_id' | 'id' | 'name' | 'secret' | 'deleted_at'
 >
 
 export type UserOutputTag = Pick<

--- a/packages/api/test/db-client.spec.js
+++ b/packages/api/test/db-client.spec.js
@@ -11,7 +11,7 @@ describe('DB Client', () => {
     client = await createClientWithUser()
   })
 
-  it('getUser should list only active keys', async () => {
+  it('getUser should list all keys', async () => {
     const issuer1 = `did:eth:0x73573${Date.now()}`
     const token1 = await signJWT(
       {
@@ -51,7 +51,7 @@ describe('DB Client', () => {
       throw new Error('no user data')
     }
     const keys = user.keys
-    assert.equal(keys.length, 2)
+    assert.equal(keys.length, 3)
     assert.equal(keys[1].name, 'key1')
   })
 })


### PR DESCRIPTION
When an API key is blocked in admin.storage, it sets deleted_at to the current time, and then sets the last auth_key_history item to have status 'Blocked.'  This PR just updates the code to look at the status so it can send a unique error to the client when an API key is deleted via a block.

Closes #1382 