### PR TITLE
fix: invalid multipart data error

### DIFF
--- a/packages/api/src/routes/nfts-upload.js
+++ b/packages/api/src/routes/nfts-upload.js
@@ -36,10 +36,16 @@ export async function nftUpload(event, ctx) {
     // encoded as binary, which is why we can expect that each part here is
     // a file (and not a stirng).
     const files = /** @type {File[]} */ (form.getAll('file'))
+    const input = files.map((f) => {
+      if (typeof f === 'string') {
+        throw new HTTPError('missing Content-Type in multipart part', 400)
+      }
+      return { path: f.name, content: f.stream() }
+    })
 
     const { car } = await packToBlob({
       // @ts-ignore nodejs readable stream type inconsistencies
-      input: files.map((f) => ({ path: f.name, content: f.stream() })),
+      input,
       wrapWithDirectory: true,
     })
 

--- a/packages/api/test/nfts-upload.spec.js
+++ b/packages/api/test/nfts-upload.spec.js
@@ -80,6 +80,21 @@ describe('NFT Upload ', () => {
     )
   })
 
+  it('should fail to upload files without Content-Type', async () => {
+    const body = new FormData()
+    const file = 'hello world! 1'
+    body.append('file', file)
+    const res = await fetch('upload', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${client.token}` },
+      body,
+    })
+    assert(res, 'Server responded')
+    assert.equal(res.status, 400, 'Server responded with HTTP 400 status')
+    const { error } = await res.json()
+    assert.equal(error.message, 'missing Content-Type in multipart part')
+  })
+
   it('should upload multiple blobs without name', async () => {
     const body = new FormData()
 


### PR DESCRIPTION
[We require a `Content-Type` to be set for each part of the multipart request.](https://nft.storage/api-docs/#operations-NFT_Storage-upload)

If users don't set this value `FormData#getAll()` returns a `string` not a `File`.

This PR prevents Sentry errors for invalid multipart (by our standards).

<img width="769" alt="Screenshot 2022-05-10 at 10 38 41" src="https://user-images.githubusercontent.com/152863/167601277-eaf08400-ad20-4471-830d-555163399256.png">