### PR TITLE
feat: optimize metrics query

### DIFF
--- a/packages/api/src/utils/db-client.js
+++ b/packages/api/src/utils/db-client.js
@@ -570,10 +570,8 @@ export class DBClient {
 
     const dagByteSizeQuery = metricsQuery
       .select('name, dimensions, value')
-      .match({
-        name: 'dagcargo_project_bytes_in_active_deals',
-        dimensions: '{{project,nft.storage}}',
-      })
+      .eq('name', 'dagcargo_project_bytes_in_active_deals')
+      .contains('dimensions', ['project', 'nft.storage'])
       .single()
 
     const weekAgo = new Date()


### PR DESCRIPTION
Fixes: #1877

This commit optimizes the metrics query to be less brittle
in the case that the dimensions array data changes or
takes on new values. Here, we query the presence
of the keys instead of the exact match of the
stringified array.