### PR TITLE
fix: file import in some ts configurations

### DIFF
--- a/packages/client/src/platform.ts
+++ b/packages/client/src/platform.ts
@@ -1,11 +1,33 @@
 import { MemoryBlockStore } from 'ipfs-car/blockstore/memory'
 
-export const fetch = globalThis.fetch
-export const FormData = globalThis.FormData
-export const Headers = globalThis.Headers
-export const Request = globalThis.Request
-export const Response = globalThis.Response
-export const Blob = globalThis.Blob
-export const File = globalThis.File
-export const ReadableStream = globalThis.ReadableStream
+declare var fetchExport: typeof fetch
+declare var FormDataExport: typeof FormData
+interface FormDataExport extends FormData {}
+
+declare var HeadersExport: typeof Headers
+interface HeadersExport extends Headers {}
+
+declare var RequestExport: typeof Request
+interface RequestExport extends Request {}
+
+declare var ResponseExport: typeof Response
+interface ResponseExport extends Response {}
+
+declare var BlobExport: typeof Blob
+interface BlobExport extends Blob {}
+
+declare var FileExport: typeof File
+interface FileExport extends File {}
+declare var ReadableStreamExport: typeof ReadableStream
+
 export const Blockstore = MemoryBlockStore
+export {
+  fetchExport as fetch,
+  FormDataExport as FormData,
+  HeadersExport as Headers,
+  RequestExport as Request,
+  ResponseExport as Response,
+  BlobExport as Blob,
+  FileExport as File,
+  ReadableStreamExport as ReadableStream,
+}


### PR DESCRIPTION
I believe this fixes #1810.

I am not sure I know what exactly is happening in the TS, but I suspect issue is related to the fact that TS defines `File` in multiple places once as interface and another time overloading `File` as a class that implements that interface. It looks like `@tsconfig/node16` config causes `File` binding to be exported as opposed to both definitions.

Fix here explicitly overloads `FileExport` the same way and then exports it as `File` which seems to force TS to recognize binding as both interface and a binding.

P.S: I attempted to create simple test case to verify this but unfortunately failed to do so as it requires setting up another package with different tsconfig and which then needs to somehow reference `nft.storage` in the tree. All in all I don't think it's worth an effort, unless we find ourselves trying running into this again. 