### PR TITLE
Fix typo in how-to/store-directory code snippet

### DIFF
--- a/packages/website/pages/docs/how-to/store-directory.md
+++ b/packages/website/pages/docs/how-to/store-directory.md
@@ -42,7 +42,7 @@ async function main() {
     console.error(`usage: ${process.argv[0]} ${process.argv[1]} <directory-path>`)
   }
   const directoryPath = process.argv[2]
-  const files = await getFilesFromPath(path, {
+  const files = await getFilesFromPath(directoryPath, {
       pathPrefix: path.resolve(directoryPath), // see the note about pathPrefix below
       hidden: true // use the default of false if you want to ignore files that start with '.'
   })


### PR DESCRIPTION
Motivation:
* I was diving into https://github.com/nftstorage/nft.storage/issues/1525 and started by following the docs as-is. When I ran the script, I got an error:
```
TypeError: paths is not async iterable
    at filesFromPath (file:///Users/bengo/protocol.ai/store-directory/node_modules/files-from-path/esm/src/index.js:27:28)
```
  * it's because the code snippet was passing the node stdlib 'path' module where I believe the function wanted one or more filesystem paths as strings