### PR TITLE
docs: Update docs/how-to/store-directory to pass files as AsyncIterable<File>

### DIFF
--- a/packages/website/pages/docs/how-to/store-directory.md
+++ b/packages/website/pages/docs/how-to/store-directory.md
@@ -65,9 +65,9 @@ main()
 
 The `filesFromPath` function is provided by the [`files-from-path` package][npm-files-from-path]. It will read the contents of a directory into `File` objects that can be passed into the NFT.Storage client.
 
-The `pathPrefix` option tells `getFilesFromPath` to remove the input `path` from the filenames of the `File` objects it creates. For example, if you're reading in files from a directory called `example`, calling `getFilesFromPath` _without_ the `pathPrefix` argument would result in `File` objects with filenames like `example/file1.txt`, `example/file2.txt`, and so on. If you set the `pathPrefix` option to `example`, you'll get `file1.txt`, `file2.txt`, etc. instead. This results in a final IPFS URI of `ipfs://<directory-cid>/file1.txt` instead of `ipfs://<directory-cid>/example/file1.txt`.
+The `pathPrefix` option tells `filesFromPath` to remove the input `path` from the filenames of the `File` objects it creates. For example, if you're reading in files from a directory called `example`, calling `filesFromPath` _without_ the `pathPrefix` argument would result in `File` objects with filenames like `example/file1.txt`, `example/file2.txt`, and so on. If you set the `pathPrefix` option to `example`, you'll get `file1.txt`, `file2.txt`, etc. instead. This results in a final IPFS URI of `ipfs://<directory-cid>/file1.txt` instead of `ipfs://<directory-cid>/example/file1.txt`.
 
-Notice that we're calling [`path.resolve`](https://nodejs.org/api/path.html#pathresolvepaths) on the `directoryPath` argument before using it as our `pathPrefix`. `getFilesFromPath` will compare the `pathPrefix` we give it to the absolute path of the file, so using `path.resolve` ensures that we give it the correct input, even if the user passed in a relative path at the command line.
+Notice that we're calling [`path.resolve`](https://nodejs.org/api/path.html#pathresolvepaths) on the `directoryPath` argument before using it as our `pathPrefix`. `filesFromPath` will compare the `pathPrefix` we give it to the absolute path of the file, so using `path.resolve` ensures that we give it the correct input, even if the user passed in a relative path at the command line.
 
 You'll need to replace `YOUR_API_TOKEN` with your NFT.Storage API key. If you don't yet have an API key, see the [Quickstart guide][quickstart].
 

--- a/packages/website/pages/docs/how-to/store-directory.md
+++ b/packages/website/pages/docs/how-to/store-directory.md
@@ -42,14 +42,10 @@ async function main() {
     console.error(`usage: ${process.argv[0]} ${process.argv[1]} <directory-path>`)
   }
   const directoryPath = process.argv[2]
-  const files = (async function* () {
-    for await (const file of filesFromPath(directoryPath, {
-      pathPrefix: path.resolve(directoryPath), // see the note about pathPrefix below
-      hidden: true, // use the default of false if you want to ignore files that start with '.'
-    })) {
-      yield new File([file.stream()], file.name);
-    }
-  })();
+  const files = filesFromPath(directoryPath, {
+    pathPrefix: path.resolve(directoryPath), // see the note about pathPrefix below
+    hidden: true, // use the default of false if you want to ignore files that start with '.'
+  })
 
   const storage = new NFTStorage({ token })
 

--- a/packages/website/pages/docs/how-to/store-directory.md
+++ b/packages/website/pages/docs/how-to/store-directory.md
@@ -30,7 +30,7 @@ npm install nft.storage files-from-path
 Create a file called `storeDirectory.mjs` and add the following code:
 
 ```js
-import { NFTStorage, File } from 'nft.storage'
+import { NFTStorage } from 'nft.storage'
 import { filesFromPath } from 'files-from-path'
 import path from 'path'
 

--- a/packages/website/pages/docs/how-to/store-directory.md
+++ b/packages/website/pages/docs/how-to/store-directory.md
@@ -31,7 +31,7 @@ Create a file called `storeDirectory.mjs` and add the following code:
 
 ```js
 import { NFTStorage, File } from 'nft.storage'
-import { getFilesFromPath } from 'files-from-path'
+import { filesFromPath } from 'files-from-path'
 import path from 'path'
 
 const token = 'YOUR_API_TOKEN'
@@ -42,14 +42,18 @@ async function main() {
     console.error(`usage: ${process.argv[0]} ${process.argv[1]} <directory-path>`)
   }
   const directoryPath = process.argv[2]
-  const files = await getFilesFromPath(directoryPath, {
+  const files = (async function* () {
+    for await (const file of filesFromPath(directoryPath, {
       pathPrefix: path.resolve(directoryPath), // see the note about pathPrefix below
-      hidden: true // use the default of false if you want to ignore files that start with '.'
-  })
+      hidden: true, // use the default of false if you want to ignore files that start with '.'
+    })) {
+      yield new File([file.stream()], file.name);
+    }
+  })();
 
   const storage = new NFTStorage({ token })
 
-  console.log(`storing ${files.length} file(s) from ${path}`)
+  console.log(`storing file(s) from ${path}`)
   const cid = await storage.storeDirectory(files)
   console.log({ cid })
 
@@ -59,15 +63,11 @@ async function main() {
 main()
 ```
 
-The `getFilesFromPath` function is provided by the [`files-from-path` package][npm-files-from-path]. It will read the contents of a directory into `File` objects that can be passed into the NFT.Storage client.
+The `filesFromPath` function is provided by the [`files-from-path` package][npm-files-from-path]. It will read the contents of a directory into `File` objects that can be passed into the NFT.Storage client.
 
 The `pathPrefix` option tells `getFilesFromPath` to remove the input `path` from the filenames of the `File` objects it creates. For example, if you're reading in files from a directory called `example`, calling `getFilesFromPath` _without_ the `pathPrefix` argument would result in `File` objects with filenames like `example/file1.txt`, `example/file2.txt`, and so on. If you set the `pathPrefix` option to `example`, you'll get `file1.txt`, `file2.txt`, etc. instead. This results in a final IPFS URI of `ipfs://<directory-cid>/file1.txt` instead of `ipfs://<directory-cid>/example/file1.txt`.
 
 Notice that we're calling [`path.resolve`](https://nodejs.org/api/path.html#pathresolvepaths) on the `directoryPath` argument before using it as our `pathPrefix`. `getFilesFromPath` will compare the `pathPrefix` we give it to the absolute path of the file, so using `path.resolve` ensures that we give it the correct input, even if the user passed in a relative path at the command line.
-
-<Callout emoji="💡">
-If your directory contains a lot of files, or if the files themselves are very large, you may want to use `filesFromPath` instead of `getFilesFromPath`. This will avoid buffering all the files into memory, but will require you to handle each `File` object individually as you pull from the returned `AsyncIterator`.
-</Callout>
 
 You'll need to replace `YOUR_API_TOKEN` with your NFT.Storage API key. If you don't yet have an API key, see the [Quickstart guide][quickstart].
 


### PR DESCRIPTION
Depends on
  * [x] https://github.com/nftstorage/nft.storage/pull/1920
  * [x] release of `nft.storage` client to npm so these docs work on latest

Motivation
* make the documented way of doing this not buffer big dirs in a way that could crash https://github.com/nftstorage/nft.storage/issues/1525