### PR TITLE
feat: storeDirectory accepts iter of file objects

### DIFF
--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -675,7 +675,7 @@ class NFTStorage {
 
 /**
  * Cast an iterable to an asyncIterable
- * @template {File|FileObject} T
+ * @template T
  * @param {Iterable<T>} iterable
  * @returns {AsyncIterable<T>}
  */

--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -23,6 +23,14 @@ export interface PublicService {
   rateLimiter?: RateLimiter
 }
 
+export interface FileObject {
+  name: string
+  size: number
+  stream: () => AsyncIterable<any>
+}
+
+export type FilesSource = Iterable<File>|Iterable<FileObject>|AsyncIterable<File>|AsyncIterable<FileObject>
+
 /**
  * CID in string representation
  */
@@ -100,7 +108,7 @@ export interface API {
    * be within the same directory, otherwise error is raised e.g. `foo/bar.png`,
    * `foo/bla/baz.json` is ok but `foo/bar.png`, `bla/baz.json` is not.
    */
-  storeDirectory(service: Service, files: Iterable<File>|AsyncIterable<File>): Promise<CIDString>
+  storeDirectory(service: Service, files: Iterable<File>|Iterable<FileObject>|AsyncIterable<File>|AsyncIterable<FileObject>): Promise<CIDString>
   /**
    * Returns current status of the stored NFT by its CID. Note the NFT must
    * have previously been stored by this account.

--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -29,7 +29,11 @@ export interface FileObject {
   stream: () => AsyncIterable<any>
 }
 
-export type FilesSource = Iterable<File>|Iterable<FileObject>|AsyncIterable<File>|AsyncIterable<FileObject>
+export type FilesSource =
+| Iterable<File>
+| Iterable<FileObject>
+| AsyncIterable<File>
+| AsyncIterable<FileObject>
 
 /**
  * CID in string representation

--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -108,7 +108,7 @@ export interface API {
    * be within the same directory, otherwise error is raised e.g. `foo/bar.png`,
    * `foo/bla/baz.json` is ok but `foo/bar.png`, `bla/baz.json` is not.
    */
-  storeDirectory(service: Service, files: Iterable<File>|Iterable<FileObject>|AsyncIterable<File>|AsyncIterable<FileObject>): Promise<CIDString>
+  storeDirectory(service: Service, files: FilesSource): Promise<CIDString>
   /**
    * Returns current status of the stored NFT by its CID. Note the NFT must
    * have previously been stored by this account.

--- a/packages/client/test/lib.spec.js
+++ b/packages/client/test/lib.spec.js
@@ -241,6 +241,36 @@ describe('client', () => {
       )
     })
 
+    it('upload multiple FileObject from files-from-path as asyncIterable', async () => {
+      const client = new NFTStorage({ token, endpoint })
+      const file1Buffer = new TextEncoder().encode('hello world')
+      const file2Buffer = new TextEncoder().encode(
+        JSON.stringify({ from: 'incognito' }, null, 2)
+      )
+      const cid = await client.storeDirectory(
+        toAsyncIterable([
+          {
+            name: 'hello.txt',
+            size: file1Buffer.length,
+            stream: async function* () {
+              yield file1Buffer
+            },
+          },
+          {
+            name: 'metadata.json',
+            size: file2Buffer.length,
+            stream: async function* () {
+              yield file2Buffer
+            },
+          },
+        ])
+      )
+
+      assert.equal(
+        cid,
+        'bafybeigkms36pnnjsa7t2mq2g4mx77s4no2hilirs4wqx3eebbffy2ay3a'
+      )
+    })
     it('upload empty files', async () => {
       const client = new NFTStorage({ token, endpoint })
       try {
@@ -741,6 +771,23 @@ describe('client', () => {
         const error = /** @type {Error} */ (err)
         assert.ok(error.message.match(/not found/))
       }
+    })
+  })
+
+  describe('static encodeDirectory', () => {
+    it('can encode multiple FileObject as iterable', async () => {
+      const files = [
+        new File(['hello world'], 'hello.txt'),
+        new File(
+          [JSON.stringify({ from: 'incognito' }, null, 2)],
+          'metadata.json'
+        ),
+      ]
+      const { cid } = await NFTStorage.encodeDirectory(files)
+      assert.equal(
+        cid.toString(),
+        'bafybeigkms36pnnjsa7t2mq2g4mx77s4no2hilirs4wqx3eebbffy2ay3a'
+      )
     })
   })
 })


### PR DESCRIPTION
Motivation:
* https://github.com/nftstorage/nft.storage/pull/1921#discussion_r876243994
* this makes it so storeDirectory can accept POJO, not just dom File objects, which can make our docs code snippets even simpler when using `files-from-path`