### PR TITLE
fix: default PSA pin status filter

### DIFF
--- a/packages/api/src/routes/pins-list.js
+++ b/packages/api/src/routes/pins-list.js
@@ -123,6 +123,10 @@ function parseSearchParams(params) {
     out.status = /** @type {ListUploadsOptions["status"]}*/ (
       statusParam.split(',').map(toDbPinStatus)
     )
+  } else {
+    // "when no filter is provided, only successful pins are returned"
+    // https://ipfs.github.io/pinning-services-api-spec/#tag/pins/paths/~1pins/get
+    out.status = ['Pinned']
   }
 
   const afterParam = params.get('after')

--- a/packages/api/test/pin-list.spec.js
+++ b/packages/api/test/pin-list.spec.js
@@ -5,7 +5,7 @@ describe('Pin list ', () => {
   /** @type{DBTestClient} */
   let client
 
-  before(async () => {
+  beforeEach(async () => {
     client = await createClientWithUser()
   })
 
@@ -68,6 +68,50 @@ describe('Pin list ', () => {
       valuePinList.results[0].requestid,
       cid,
       'Server response with pin requests created'
+    )
+  })
+
+  it('should list pinned items when querying without filters', async () => {
+    // List
+    const resEmptyPinList = await fetch('pins', {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${client.token}` },
+    })
+    const valueEmptyPinList = await resEmptyPinList.json()
+    assert.strictEqual(
+      valueEmptyPinList.count,
+      0,
+      'Server response with empty pin requests'
+    )
+
+    // Pin request
+    const cid = 'bafkreihwlixzeusjrd5avlg53yidaoonf5r5srzumu7y5uuumtt7rxxbrm'
+    const resPinCreate = await fetch('pins', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${client.token}` },
+      body: JSON.stringify({ cid }),
+    })
+    assert.ok(resPinCreate.ok, 'Server responde ok')
+
+    // Upload
+    const file = new Blob(['hello world!'], { type: 'application/text' })
+    const res = await fetch('upload', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${client.token}` },
+      body: file,
+    })
+    assert(res.ok, 'Server response ok')
+
+    // List
+    const resPinList = await fetch('pins', {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${client.token}` },
+    })
+    const valuePinList = await resPinList.json()
+    assert.strictEqual(
+      valuePinList.count,
+      1,
+      'Server response with 1 successful pin request'
     )
   })
 })


### PR DESCRIPTION
`status` filter is not a required param, it should be implicity set to 'pinned' when not set by the client.

resolves #1933

cc @flea89 