### PR TITLE
chore: add jobs key

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'packages/cron/**'
       - '.github/workflows/cron.yml'
+jobs:
   release:
     name: Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Cron workflow setup file is missing the job key.

Error [here](https://github.com/nftstorage/nft.storage/actions/runs/2460571231)