### PR TITLE
docs: add store from URL example

### DIFF
--- a/examples/client/browser/README.md
+++ b/examples/client/browser/README.md
@@ -13,8 +13,8 @@ These demos use the pre-built bundle served by https://www.jsdelivr.com/.
 
 Register an account at https://nft.storage and create a new API key.
 
-Open `store.html`/`storeBlob.html`/`storeDirectory.html` and replace `API_KEY` in the code with your key.
+Open one of the `.html` files in this directory and replace `API_KEY` in the code with your key.
 
 ## Running
 
-Open `store.html`/`storeBlob.html`/`storeDirectory.html` in your favourite web browser.
+Open one of the `.html` files in this directory in your favourite web browser.

--- a/examples/client/browser/README.md
+++ b/examples/client/browser/README.md
@@ -5,6 +5,7 @@ Examples using the nft.storage client from the browser.
 - `store.html` - creates ERC-1155 compatible metadata
 - `storeBlob.html` - uploads a single file using `storeBlob`
 - `storeDirectory.html` - uploads a multiple files using `storeDirectory`
+- `storeFromUrl.html` - creates ERC-1155 compatible metadata with image data retrieved from a URL
 
 These demos use the pre-built bundle served by https://www.jsdelivr.com/.
 

--- a/examples/client/browser/storeFromUrl.html
+++ b/examples/client/browser/storeFromUrl.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<form>
+  <label> Name: <input type="text" /> </label>
+  <label> URL: <input type="url" /> </label>
+  <div>
+    <button type="submit">Store</button>
+  </div>
+</form>
+<pre id="out"></pre>
+<script type="module">
+  import { NFTStorage } from 'https://cdn.jsdelivr.net/npm/nft.storage/dist/bundle.esm.min.js'
+
+  const token =
+    new URLSearchParams(window.location.search).get('key') || 'API_KEY' // your API key from https://nft.storage/manage
+
+  function log(msg) {
+    msg = JSON.stringify(msg, null, 2)
+    document.getElementById('out').innerHTML += `${msg}\n`
+  }
+
+  document.querySelector('form').addEventListener('submit', async (e) => {
+    e.preventDefault()
+    const name = document.querySelector('input[type="text"]').value
+    if (!name) return log('Missing name')
+
+    const urlEl = document.querySelector('input[type="url"]')
+    if (!urlEl.value) return log('Missing URL')
+
+    const url = new URL(urlEl.value)
+    const res = await fetch(url.toString())
+    const fileName = url.pathname.endsWith('/')
+      ? 'blob'
+      : url.pathname.split('/').pop()
+    const data = await res.blob()
+    const image = new File([data], fileName)
+    const description = 'Example store by fetching from URL.'
+
+    const storage = new NFTStorage({ token })
+    try {
+      const metadata = await storage.store({ name, description, image })
+      log({ 'IPFS URL for the metadata': metadata.url })
+      log({ 'metadata.json contents': metadata.data })
+      log({ 'metadata.json contents with IPFS gateway URLs': metadata.embed() })
+    } catch (err) {
+      console.error(err)
+      log(err.message)
+    }
+  })
+</script>


### PR DESCRIPTION
Adds an example showing how to store ERC-721 compatible metadata with image data retrieved from a URL on the internet.

Adapted from https://github.com/nftstorage/nft.storage/blob/main/examples/client/browser/store.html