### PR TITLE
fix: add underline style to tooltip hyperlinks

### DIFF
--- a/packages/website/styles/tooltip.css
+++ b/packages/website/styles/tooltip.css
@@ -19,4 +19,5 @@
 .rc-tooltip.ns-tooltip .rc-tooltip-content a,
 .rc-tooltip.ns-tooltip .rc-tooltip-content a:visited {
   color: #000;
+  text-decoration: underline;
 }


### PR DESCRIPTION
fixes #1976
This PR adds an underline style to tooltip hyperlinks that would otherwise look like plain text. The color remains #000 to stay consistent with the current style guide.