### PR TITLE
fix: cron-nft-ttr workflow no longer has staging/prod env matrix

### DIFF
--- a/.github/workflows/cron-nft-ttr.yml
+++ b/.github/workflows/cron-nft-ttr.yml
@@ -9,9 +9,6 @@ jobs:
   measure:
     name: measure nft time to retrievability
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        env: ['staging', 'production']
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
@@ -22,7 +19,6 @@ jobs:
       - name: Run job
         env:
           DEBUG: '*'
-          ENV: ${{ matrix.env }}
           NFT_STORAGE_API_KEY: ${{ secrets.NFT_STORAGE_API_KEY }}
           PUSHGATEWAY_JOBNAME: nftstorage_ci/instance/github_action
           PUSHGATEWAY_URL: https://pushgateway.k8s.locotorp.info/metrics/job/nftstorage_ci/instance/github_action


### PR DESCRIPTION
Motivation
* when checking on this new cronjob, I noticed that there were two jobs running instead of one. https://github.com/nftstorage/nft.storage/actions/runs/2517588405
  * this is unintended and because I copypastad the env matrix
  * it's probably a good idea to matrix this across production and staging envs, but that wasn't my original intention so want to remove this asap. we can add a staging check later once we know the check is working/useful against prod