### PR TITLE
fix: link to NFTStorage constructor in API reference docs

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -57,11 +57,11 @@ Run the script:
 node index.mjs # or index.js
 ```
 
-For more examples please see the [API documentation](https://nftstorage.github.io/nft.storage/client/) or the [examples directory in the project repository][examples directory], which contains sample projects for both [browsers][examples.browser] and [Node.js][examples.node].
+For more examples please see the [API documentation](https://nftstorage.github.io/nft.storage/client/classes/lib.NFTStorage.html) or the [examples directory in the project repository][examples directory], which contains sample projects for both [browsers][examples.browser] and [Node.js][examples.node].
 
 [raw http api]: https://nft.storage/api-docs/
 [node.js]: https://nodejs.org/
-[api documentation]: https://nftstorage.github.io/nft.storage/client/
+[api documentation]: https://nftstorage.github.io/nft.storage/client/classes/lib.NFTStorage.html
 [examples directory]: https://github.com/nftstorage/nft.storage/tree/main/examples/client
 [examples.node]: https://github.com/nftstorage/nft.storage/tree/main/examples/client/node.js
 [examples.browser]: https://github.com/nftstorage/nft.storage/tree/main/examples/client/browser

--- a/packages/website/pages/docs/client/js.md
+++ b/packages/website/pages/docs/client/js.md
@@ -133,7 +133,7 @@ The entry for the data will be removed from your account's file listing page, an
 
 ## API reference
 
-Full [API reference documentation](reference-nftstorage-class).
+Full [API reference documentation][reference-nftstorage-class].
 
 [quickstart]: /docs/
 [reference-http-api]: /api-docs/

--- a/packages/website/pages/docs/client/js.md
+++ b/packages/website/pages/docs/client/js.md
@@ -9,7 +9,7 @@ The JavaScript client uses the [HTTP API][reference-http-api] to send your data 
 
 Encoding the data locally has another benefit of reducing the trust required of the NFT.Storage service. By calculating all of the [Content Identifiers (CIDs)][concepts-cid] for your data yourself, you can make sure that the data you send is exactly what gets provided to the network. Any alteration of your data by the NFT.Storage service or a third party "monster in the middle" would result in a different CID, which the client will reject as an error.
 
-This guide will cover the basics of creating a client object, as well as the most common and useful operations. For more details, see the complete [client API documentation][reference-nftstorage-class]. For fewer, see the [Quickstart guide][quickstart]!
+This guide will cover the basics of creating a client object, as well as the most common and useful operations. For more details, see the complete [client API documentation][reference-nftstorage-class]. For less, see the [Quickstart guide][quickstart]!
 
 ## Installation and importing
 

--- a/packages/website/pages/docs/client/js.md
+++ b/packages/website/pages/docs/client/js.md
@@ -9,7 +9,7 @@ The JavaScript client uses the [HTTP API][reference-http-api] to send your data 
 
 Encoding the data locally has another benefit of reducing the trust required of the NFT.Storage service. By calculating all of the [Content Identifiers (CIDs)][concepts-cid] for your data yourself, you can make sure that the data you send is exactly what gets provided to the network. Any alteration of your data by the NFT.Storage service or a third party "monster in the middle" would result in a different CID, which the client will reject as an error.
 
-This guide will cover the basics of creating a client object, as well as the most common and useful operations. For more details, see the complete [client API documentation][reference-client-api]. For fewer, see the [Quickstart guide][quickstart]!
+This guide will cover the basics of creating a client object, as well as the most common and useful operations. For more details, see the complete [client API documentation][reference-nftstorage-class]. For fewer, see the [Quickstart guide][quickstart]!
 
 ## Installation and importing
 
@@ -131,6 +131,10 @@ The [`delete`][reference-delete] method can remove uploaded data from your accou
 
 The entry for the data will be removed from your account's file listing page, and the NFT.Storage service may stop providing the data to the IPFS network and managing Filecoin storage deals. However, any peers in the storage networks who have obtained a copy of the data may continue to store it and may continue to provide the data to the network at their discretion.
 
+## API reference
+
+Full [API reference documentation](reference-nftstorage-class).
+
 [quickstart]: /docs/
 [reference-http-api]: /api-docs/
 [concepts-car]: /docs/concepts/car-files/
@@ -140,7 +144,6 @@ The entry for the data will be removed from your account's file listing page, an
 
 
 { /* TODO: update links once API docs are moved into the main site */ }
-[reference-client-api]: https://nftstorage.github.io/nft.storage/client/
 [reference-nftstorage-class]: https://nftstorage.github.io/nft.storage/client/classes/lib.NFTStorage.html
 [reference-store]: https://nftstorage.github.io/nft.storage/client/classes/lib.NFTStorage.html#store
 [reference-storeBlob]: https://nftstorage.github.io/nft.storage/client/classes/lib.NFTStorage.html#storeBlob

--- a/packages/website/pages/docs/concepts/architecture-considerations.md
+++ b/packages/website/pages/docs/concepts/architecture-considerations.md
@@ -13,7 +13,7 @@ There are currently two methods of authenticating uploads to NFT.Storage, and wh
 
 ### API Keys
 
-The most common way to authenticate is using an **API Key**, which can be generated on your [account management page](https://nft.storage/manage/) on the NFT.Storage website. Once you've generated a key, you can use it to authenticate the [JavaScript client][reference-js-client] or attach the key to an `Authentication` header in requests to the [HTTP API][reference-http].
+The most common way to authenticate is using an **API Key**, which can be generated on your [account management page](https://nft.storage/manage/) on the NFT.Storage website. Once you've generated a key, you can use it to authenticate the [JavaScript client][reference-nftstorage-class] or attach the key to an `Authentication` header in requests to the [HTTP API][reference-http].
 
 While API keys are easy to use, they need to be protected and kept secret to avoid giving access to your NFT.Storage account. As a result, we strongly advise against including your API key in web apps or other client applications where the key may be exposed and potentially extracted and misused.
 
@@ -70,7 +70,7 @@ Because public gateways are a shared resource, you may prefer to [run your own d
 Another potential optimization is to store redundant copies of your NFT data on a traditional storage service and deliver them via HTTP. This side-steps the IPFS retrieval entirely and may be more performant in some cases, but you'll need to do some bookkeeping to keep track of the HTTP locations of each piece of data. When pursuing this option, we strongly recommend exposing the original `ipfs://` URLs to your users, so that they have multiple options for retrieval and aren't dependent on your custom HTTP service.
 
 
-[reference-js-client]: https://nftstorage.github.io/nft.storage/client
+[reference-nftstorage-class]: https://nftstorage.github.io/nft.storage/client/classes/lib.NFTStorage.html
 [reference-http]: https://nft.storage/api-docs/
 [brave-ipfs]: https://brave.com/ipfs-support/
 [public-gateway-checker]: https://ipfs.github.io/public-gateway-checker/


### PR DESCRIPTION
The `NFTStorage` class page is where folks need to be directed to.

Also adds a menu item to the reference docs.