### PR TITLE
fix: fix cron-nft-ttr logging, multiple gateway support

### DIFF
--- a/.github/workflows/cron-nft-ttr.yml
+++ b/.github/workflows/cron-nft-ttr.yml
@@ -28,7 +28,6 @@ jobs:
           PUSHGATEWAY_URL: https://pushgateway.k8s.locotorp.info/metrics/job/nftstorage_ci/instance/github_action
           PUSHGATEWAY_BASIC_AUTH: ${{ secrets.PUSHGATEWAY_BASIC_AUTH }}
         run: |
-          yarn workspace cron run start:nft-ttr measure --logConfigAndExit
           yarn workspace cron run start:nft-ttr measure \
             --minImageSizeBytes=10000000 \
             --gateways https://nftstorage.link https://dweb.link \

--- a/.github/workflows/cron-nft-ttr.yml
+++ b/.github/workflows/cron-nft-ttr.yml
@@ -30,7 +30,8 @@ jobs:
         run: |
           yarn workspace cron run start:nft-ttr measure \
             --minImageSizeBytes=10000000 \
-            --gateways https://nftstorage.link https://dweb.link \
+            --gateway https://nftstorage.link \
+            --gateway https://dweb.link \
             --metricsPushGateway $PUSHGATEWAY_URL \
             --metricsPushGatewayJobName $PUSHGATEWAY_JOBNAME \
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -8,8 +8,6 @@ on:
       - '.github/workflows/cron.yml'
       - 'yarn.lock'
   pull_request:
-    branches:
-      - main
     paths:
       - 'packages/cron/**'
       - '.github/workflows/cron.yml'

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -52,6 +52,9 @@
     "eslint-plugin-prettier": "^4.0.0",
     "npm-run-all": "^4.1.5"
   },
+  "ava": {
+    "workerThreads": false
+  },
   "eslintConfig": {
     "plugins": [
       "@typescript-eslint"

--- a/packages/cron/src/bin/nft-ttr.js
+++ b/packages/cron/src/bin/nft-ttr.js
@@ -209,7 +209,9 @@ export async function* cli(
       iterable = measureNftTimeToRetrievability({
         secrets,
         ...createMeasureOptionsFromSade(opts, secrets),
-        ...options,
+        ...(options.fetchImage ? { fetchImage: options.fetchImage } : {}),
+        ...(options.store ? { store: options.store } : {}),
+        console: options.console,
       })
     })
   argParser.parse(argv)
@@ -233,8 +235,8 @@ function parseBasicAuth(basicAuthEnvVarString) {
  * @param {string[]} argv
  */
 async function main(argv) {
-  // eslint-disable-next-line no-empty,@typescript-eslint/no-unused-vars,no-unused-vars
-  for await (const _ of cli(argv)) {
+  for await (const _ of cli(argv, { console, env: process.env })) {
+    console.debug(_)
   }
 }
 

--- a/packages/cron/src/bin/nft-ttr.js
+++ b/packages/cron/src/bin/nft-ttr.js
@@ -69,14 +69,14 @@ export function createMeasureSecretsFromEnv(env) {
 export function createMeasureOptionsFromSade(sadeOptions, secrets) {
   // build gateways
   assert.ok(
-    hasOwnProperty(sadeOptions, 'gateways'),
-    'expected sadeOptions to have gateways'
+    hasOwnProperty(sadeOptions, 'gateway'),
+    'expected sadeOptions to have gateway'
   )
-  const gatewaysArgv = sadeOptions.gateways
-  assert.ok(Array.isArray(gatewaysArgv) || typeof gatewaysArgv === 'string')
-  const gatewaysArgvsArray = Array.isArray(gatewaysArgv)
-    ? gatewaysArgv.map(String)
-    : [...gatewaysArgv.split(' ')]
+  const gatewayArgv = sadeOptions.gateway
+  assert.ok(Array.isArray(gatewayArgv) || typeof gatewayArgv === 'string')
+  const gatewaysArgvsArray = Array.isArray(gatewayArgv)
+    ? gatewayArgv.map(String)
+    : gatewayArgv.split(' ')
   const gateways = gatewaysArgvsArray.map((g) => {
     try {
       return new URL(g)
@@ -117,6 +117,10 @@ export function createMeasureOptionsFromSade(sadeOptions, secrets) {
   const metricsPushGatewayJobName =
     hasOwnProperty(sadeOptions, 'metricsPushGatewayJobName') &&
     sadeOptions.metricsPushGatewayJobName
+  assert.ok(
+    metricsPushGatewayJobName,
+    'expected metricsPushGatewayJobName to be set'
+  )
   assert.ok(typeof metricsPushGatewayJobName === 'string')
 
   // build pushRetrieveMetrics
@@ -197,8 +201,8 @@ export async function* cli(
       false
     )
     .option(
-      '--gateways',
-      'IPFS gateway(s) to use to measure time to retrieval of the upload',
+      '--gateway',
+      'IPFS gateway to use to measure time to retrieval of the upload',
       'https://nftstorage.link'
     )
     .option(

--- a/packages/cron/src/bin/nft-ttr.js
+++ b/packages/cron/src/bin/nft-ttr.js
@@ -196,11 +196,6 @@ export async function* cli(
       'nft-ttr'
     )
     .option(
-      '--logConfigAndExit',
-      'if provided, this job will log the config and exit without doing much else. Intended for debugging',
-      false
-    )
-    .option(
       '--gateway',
       'IPFS gateway to use to measure time to retrieval of the upload',
       'https://nftstorage.link'

--- a/packages/cron/src/bin/nft-ttr.spec.js
+++ b/packages/cron/src/bin/nft-ttr.spec.js
@@ -1,8 +1,16 @@
 import { test } from '../lib/testing.js'
 import {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-unused-vars
+  cli as binNftTtr,
   createMeasureOptionsFromSade,
   createMeasureSecretsFromEnv,
 } from './nft-ttr.js'
+import {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-unused-vars
+  createStubbedImageFetcher,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-unused-vars
+  createStubStoreFunction,
+} from '../jobs/measureNftTimeToRetrievability.js'
 
 test('createMeasureOptionsFromSade', (t) => {
   const sampleSade = {

--- a/packages/cron/src/bin/nft-ttr.spec.js
+++ b/packages/cron/src/bin/nft-ttr.spec.js
@@ -1,17 +1,8 @@
 import { test } from '../lib/testing.js'
 import {
-  cli as binNftTtr,
   createMeasureOptionsFromSade,
   createMeasureSecretsFromEnv,
 } from './nft-ttr.js'
-import {
-  createStubbedImageFetcher,
-  createStubStoreFunction,
-} from '../jobs/measureNftTimeToRetrievability.js'
-import all from 'it-all'
-import { Writable } from 'node:stream'
-
-const defaultTestMinImageSizeBytes = 10 * 1e6
 
 test('createMeasureOptionsFromSade', (t) => {
   const sampleSade = {
@@ -21,14 +12,15 @@ test('createMeasureOptionsFromSade', (t) => {
       'https://pushgateway.k8s.locotorp.info/metrics/job/nftstorage_ci/instance/github_action',
     url: 'https://nft.storage',
     metricsPushGatewayJobName: 'nft-ttr',
-    gateways: 'https://nftstorage.link/',
+    gateway: ['https://nftstorage.link/', 'https://dweb.link/'],
   }
   const options = createMeasureOptionsFromSade(sampleSade, {
     metricsPushGatewayAuthorization: '',
   })
   t.assert(options)
-  t.is(options.gateways.length, 1)
-  t.is(options.gateways[0].toString(), sampleSade.gateways)
+  t.is(options.gateways.length, 2)
+  t.is(options.gateways[0].toString(), sampleSade.gateway[0])
+  t.is(options.gateways[1].toString(), sampleSade.gateway[1])
   t.is(options.metricsPushGateway?.toString(), sampleSade.metricsPushGateway)
   t.is(options.metricsPushGatewayJobName, sampleSade.metricsPushGatewayJobName)
 })
@@ -51,51 +43,4 @@ test('createMeasureSecretsFromEnv', (t) => {
     }).metricsPushGatewayAuthorization,
     'Basic dXNlcjpwYXNz'
   )
-})
-
-test(`bin/nft-ttr works with --minImageSizeBytes=${defaultTestMinImageSizeBytes} and multiple gateways`, async (t) => {
-  const minImageSizeBytes = defaultTestMinImageSizeBytes
-  const gateways = ['https://nftstorage.link', 'https://dweb.link']
-  const command = [
-    'fakeNodePath',
-    'fakeScriptPath',
-    'measure',
-    `--minImageSizeBytes=${minImageSizeBytes}`,
-    `--gateways=${gateways.join(' ')}`,
-  ]
-  const activities = await all(
-    binNftTtr(command, {
-      console: new console.Console(new Writable(), new Writable()),
-      env: {
-        NFT_STORAGE_API_KEY: '',
-      },
-      store: createStubStoreFunction(),
-      fetchImage: createStubbedImageFetcher(minImageSizeBytes),
-    })
-  )
-  let retrieveCount = 0
-  const gatewaysNeedingRetrieval = new Set(gateways)
-  for (const activity of activities) {
-    if (activity.type !== 'retrieve') {
-      continue
-    }
-    const retrieve = activity
-    retrieveCount++
-    t.assert(retrieve)
-    t.is(
-      typeof retrieve.duration.size,
-      'number',
-      'expected retrieve duration size to be a number'
-    )
-    t.assert(retrieve.contentLength > minImageSizeBytes)
-    for (const gateway of gatewaysNeedingRetrieval) {
-      if (retrieve.url.toString().startsWith(gateway)) {
-        gatewaysNeedingRetrieval.delete(gateway)
-        break
-      }
-    }
-  }
-  t.is(gatewaysNeedingRetrieval.size, 0)
-  t.is(typeof retrieveCount, 'number')
-  t.is(retrieveCount, gateways.length)
 })

--- a/packages/cron/src/bin/nft-ttr.spec.js
+++ b/packages/cron/src/bin/nft-ttr.spec.js
@@ -1,16 +1,17 @@
 import { test } from '../lib/testing.js'
 import {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-unused-vars
   cli as binNftTtr,
   createMeasureOptionsFromSade,
   createMeasureSecretsFromEnv,
 } from './nft-ttr.js'
 import {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-unused-vars
   createStubbedImageFetcher,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-unused-vars
   createStubStoreFunction,
 } from '../jobs/measureNftTimeToRetrievability.js'
+import all from 'it-all'
+import { Writable } from 'node:stream'
+
+const defaultTestMinImageSizeBytes = 10 * 1e6
 
 test('createMeasureOptionsFromSade', (t) => {
   const sampleSade = {
@@ -51,4 +52,51 @@ test('createMeasureSecretsFromEnv', (t) => {
     }).metricsPushGatewayAuthorization,
     'Basic dXNlcjpwYXNz'
   )
+})
+
+test(`bin/nft-ttr works with --minImageSizeBytes=${defaultTestMinImageSizeBytes} and multiple gateways`, async (t) => {
+  const minImageSizeBytes = defaultTestMinImageSizeBytes
+  const gateways = ['https://nftstorage.link', 'https://dweb.link']
+  const command = [
+    'fakeNodePath',
+    'fakeScriptPath',
+    'measure',
+    `--minImageSizeBytes=${minImageSizeBytes}`,
+    ...gateways.flatMap((g) => [`--gateway`, g]),
+  ]
+  const activities = await all(
+    binNftTtr(command, {
+      console: new console.Console(new Writable(), new Writable()),
+      env: {
+        NFT_STORAGE_API_KEY: '',
+      },
+      store: createStubStoreFunction(),
+      fetchImage: createStubbedImageFetcher(minImageSizeBytes),
+    })
+  )
+  let retrieveCount = 0
+  const gatewaysNeedingRetrieval = new Set(gateways)
+  for (const activity of activities) {
+    if (activity.type !== 'retrieve') {
+      continue
+    }
+    const retrieve = activity
+    retrieveCount++
+    t.assert(retrieve)
+    t.is(
+      typeof retrieve.duration.size,
+      'number',
+      'expected retrieve duration size to be a number'
+    )
+    t.assert(retrieve.contentLength > minImageSizeBytes)
+    for (const gateway of gatewaysNeedingRetrieval) {
+      if (retrieve.url.toString().startsWith(gateway)) {
+        gatewaysNeedingRetrieval.delete(gateway)
+        break
+      }
+    }
+  }
+  t.is(gatewaysNeedingRetrieval.size, 0)
+  t.is(typeof retrieveCount, 'number')
+  t.is(retrieveCount, gateways.length)
 })

--- a/packages/cron/src/bin/nft-ttr.spec.js
+++ b/packages/cron/src/bin/nft-ttr.spec.js
@@ -96,5 +96,6 @@ test(`bin/nft-ttr works with --minImageSizeBytes=${defaultTestMinImageSizeBytes}
     }
   }
   t.is(gatewaysNeedingRetrieval.size, 0)
+  t.is(typeof retrieveCount, 'number')
   t.is(retrieveCount, gateways.length)
 })

--- a/packages/cron/src/jobs/measureNftTimeToRetrievability.js
+++ b/packages/cron/src/jobs/measureNftTimeToRetrievability.js
@@ -67,7 +67,6 @@ export function createStubStoreFunction() {
  * @property {AsyncIterable<Blob>} images - images to upload/retrieve
  * @property {StoreFunction} [store] - function to store nft
  * @property {string} [url] - URL to nft.storage to measure
- * @property {boolean} [logConfigAndExit] - if true, log config and exit
  * @property {URL} [metricsPushGateway] - Server to send metrics to. should reference a https://github.com/prometheus/pushgateway
  * @property {URL[]} gateways - IPFS Gateway to test retrieval from
  * @property {Console} console - logger
@@ -125,10 +124,6 @@ function readMeasureTtrOptions(options) {
 export async function* measureNftTimeToRetrievability(options) {
   // separate secrets and config to avoid logging secrets
   const { secrets, config } = readMeasureTtrOptions(options)
-  if (config.logConfigAndExit) {
-    config.console.log(config)
-    return
-  }
   /** @type {Activity<"start">} */
   const start = {
     type: 'start',


### PR DESCRIPTION
Motivation:
* after merging #1945 into main so gh actions cron would run it, I took a look https://github.com/nftstorage/nft.storage/actions/runs/2518516959 and found some things to fix
* the stdout of the gh action job didn't include all logs of what happened. This PR logs them all so we have visibility into what is going on
* when devving I also noticed that whereas the gh action was trying to pass 2 different ipfs gateways to test retrieving through, only the first was getting used. This PR fixes the sade parsing and cli invocation to pass two gateways through two `--gateway {gatewayUrl}` flags (space-delimited values used to work with yargs, but not so easy with sade, so for now lets just do one-value-per-flag)
* see https://github.com/nftstorage/nft.storage/pull/2008 which merged in here
