### PR TITLE
test: rm test of bin/nft-ttr cli func

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -8,8 +8,6 @@ on:
       - '.github/workflows/cron.yml'
       - 'yarn.lock'
   pull_request:
-    branches:
-      - main
     paths:
       - 'packages/cron/**'
       - '.github/workflows/cron.yml'

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -52,6 +52,9 @@
     "eslint-plugin-prettier": "^4.0.0",
     "npm-run-all": "^4.1.5"
   },
+  "ava": {
+    "workerThreads": false
+  },
   "eslintConfig": {
     "plugins": [
       "@typescript-eslint"


### PR DESCRIPTION
Motivation
* in review of #1945 , @alanshaw encoruaged me to remove this test. But when I tried, it led to an error when running the tests in github action. That appears due to combination of https://sharp.pixelplumbing.com/install#worker-threads and ava's default test isolation strategy which is to use worker threads. I tried configuring ava `require` opt to require sharp, but that didn't work. So let's just disable worker threads in ava in favor of using separate processes.
  * an alternative solution would be to not use sharp since it has this worker thread quirk