### PR TITLE
cron-nft-ttr checks out latest git tag cron- (from release-please)

### DIFF
--- a/.github/workflows/cron-nft-ttr.yml
+++ b/.github/workflows/cron-nft-ttr.yml
@@ -12,6 +12,12 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Checkout latest cron release tag
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match='cron-*')
+          git checkout $LATEST_TAG
       - uses: actions/setup-node@v2
         with:
           node-version: 16


### PR DESCRIPTION
instead of running against main branch

Motivation:
* https://github.com/nftstorage/nft.storage/issues/2002