### PR TITLE
cron-nft-ttr gh action adjust PUSHGATEWAY_JOBNAME and PUSHGATEWAY_URL for prom-client

### DIFF
--- a/.github/workflows/cron-nft-ttr.yml
+++ b/.github/workflows/cron-nft-ttr.yml
@@ -26,8 +26,8 @@ jobs:
         env:
           DEBUG: '*'
           NFT_STORAGE_API_KEY: ${{ secrets.NFT_STORAGE_API_KEY }}
-          PUSHGATEWAY_JOBNAME: nftstorage_ci/instance/github_action
-          PUSHGATEWAY_URL: https://pushgateway.k8s.locotorp.info/metrics/job/nftstorage_ci/instance/github_action
+          PUSHGATEWAY_JOBNAME: nftstorage_ci
+          PUSHGATEWAY_URL: https://pushgateway.k8s.locotorp.info
           PUSHGATEWAY_BASIC_AUTH: ${{ secrets.PUSHGATEWAY_BASIC_AUTH }}
         run: |
           yarn workspace cron run start:nft-ttr measure --logConfigAndExit


### PR DESCRIPTION
Motivation:
* I'm trying to figure out why I can't find any `retrieval_duration_seconds_bucket` [in grafana](retrieval_duration_seconds_sum{job="bengo-laptop"}) from gh actions
* My latest theory is that the values passed to the script aren't working right for prom-client, and that prom-client
* prom-client seems to expect no `/metrics/...` suffix on the PUSHGATEWAY_URL https://github.com/siimon/prom-client/blob/master/lib/pushgateway.js#L50
* If we want an `instance` label (not just `job`), we may need to pass it explicitly in the prom-client.pushAdd invocation https://github.com/siimon/prom-client/blob/master/lib/pushgateway.js#L23

Other ideas:
* I could log the response status code from the push response, which I think is returned here https://github.com/nftstorage/nft.storage/blob/main/packages/cron/src/jobs/measureNftTimeToRetrievability.js#L312