### PR TITLE
ci: .github/workflows/cron.yml main is triggered on updates to .github/workflows/cron-nft-ttr.yml 

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'packages/cron/**'
       - '.github/workflows/cron.yml'
+      - '.github/workflows/cron-nft-ttr.yml'
       - 'yarn.lock'
   pull_request:
     branches:


### PR DESCRIPTION
so that updates to the latter will trigger release-please on the former

Motivation:
* I expected merging https://github.com/nftstorage/nft.storage/pull/2014 to trigger a release-please for cron, but it didn't