### PR TITLE
feat(cron): send instance=github_action label with retrieval_duration_seconds metric

### DIFF
--- a/.github/workflows/cron-nft-ttr.yml
+++ b/.github/workflows/cron-nft-ttr.yml
@@ -36,6 +36,7 @@ jobs:
             --gateway https://dweb.link \
             --metricsPushGateway $PUSHGATEWAY_URL \
             --metricsPushGatewayJobName $PUSHGATEWAY_JOBNAME \
+            --metricsLabelsJson '{"instance": "github_action"}' \
 
       - name: Heartbeat
         if: ${{ success() }}

--- a/packages/cron/src/bin/nft-ttr.js
+++ b/packages/cron/src/bin/nft-ttr.js
@@ -64,7 +64,7 @@ export function createMeasureSecretsFromEnv(env) {
 /**
  * @param {unknown} sadeOptions
  * @param {Pick<MeasureTtrOptions['secrets'], 'metricsPushGatewayAuthorization'>} secrets
- * @returns {Omit<MeasureTtrOptions, "secrets">}
+ * @returns {Omit<MeasureTtrOptions, "secrets"> & { metricsLabels: Record<string,string> }}
  */
 export function createMeasureOptionsFromSade(sadeOptions, secrets) {
   // build gateways
@@ -119,6 +119,13 @@ export function createMeasureOptionsFromSade(sadeOptions, secrets) {
     sadeOptions.metricsPushGatewayJobName
   assert.ok(typeof metricsPushGatewayJobName === 'string')
 
+  const metricsLabelsJson = hasOwnProperty(sadeOptions, 'metricsLabelsJson')
+    ? String(sadeOptions.metricsLabelsJson)
+    : undefined
+  const metricsLabels = metricsLabelsJson
+    ? /** @type {Record<string,string>} */ (JSON.parse(metricsLabelsJson))
+    : {}
+
   // build pushRetrieveMetrics
   const promClientRegistry = new promClient.Registry()
 
@@ -129,7 +136,7 @@ export function createMeasureOptionsFromSade(sadeOptions, secrets) {
         promClientRegistry,
         createRetrievalDurationMetric(promClientRegistry),
         metricsPushGatewayJobName,
-        {},
+        metricsLabels,
         metricsPushGateway,
         secrets.metricsPushGatewayAuthorization
       )
@@ -149,6 +156,7 @@ export function createMeasureOptionsFromSade(sadeOptions, secrets) {
     metricsPushGatewayJobName,
     minImageSizeBytes,
     pushRetrieveMetrics,
+    metricsLabels,
   }
   return options
 }

--- a/packages/cron/src/bin/nft-ttr.js
+++ b/packages/cron/src/bin/nft-ttr.js
@@ -129,6 +129,7 @@ export function createMeasureOptionsFromSade(sadeOptions, secrets) {
         promClientRegistry,
         createRetrievalDurationMetric(promClientRegistry),
         metricsPushGatewayJobName,
+        {},
         metricsPushGateway,
         secrets.metricsPushGatewayAuthorization
       )

--- a/packages/cron/src/bin/nft-ttr.spec.js
+++ b/packages/cron/src/bin/nft-ttr.spec.js
@@ -15,6 +15,7 @@ test('createMeasureOptionsFromSade', (t) => {
     metricsPushGatewayJobName: 'nft-ttr',
     gateway: sampleGateways,
     logConfigAndExit: true,
+    metricsLabelsJson: '{"instance": "github_action"}',
   }
   const secrets = {
     metricsPushGatewayAuthorization: '',
@@ -27,6 +28,7 @@ test('createMeasureOptionsFromSade', (t) => {
   t.is(options.metricsPushGateway?.toString(), sampleSade.metricsPushGateway)
   t.is(options.metricsPushGatewayJobName, sampleSade.metricsPushGatewayJobName)
   t.is(options.logConfigAndExit, true)
+  t.is(options.metricsLabels.instance, 'github_action')
 
   // ensure single gateway is parsed correctly
   const options2 = createMeasureOptionsFromSade(

--- a/packages/cron/src/jobs/measureNftTimeToRetrievability.js
+++ b/packages/cron/src/jobs/measureNftTimeToRetrievability.js
@@ -297,6 +297,7 @@ export function createStubbedRetrievalMetricsLogger() {
  * @param {import('prom-client').Registry} registry
  * @param {import('../lib/metrics.js').RetrievalDurationMetric} metric
  * @param {string} metricsPushGatewayJobName
+ * @param {Record<string,string>} metricLabels
  * @param {URL} pushGatewayUrl
  * @param {HttpAuthorizationHeaderValue} pushGatewayAuthorization
  * @returns {RetrievalMetricsLogger}
@@ -305,6 +306,7 @@ export function createPromClientRetrievalMetricsLogger(
   registry,
   metric,
   metricsPushGatewayJobName,
+  metricLabels,
   pushGatewayUrl,
   pushGatewayAuthorization
 ) {
@@ -323,6 +325,7 @@ export function createPromClientRetrievalMetricsLogger(
     metric.observe(value, {})
     const pushAddArgs = {
       jobName: metricsPushGatewayJobName,
+      groupings: metricLabels,
     }
     const pushAddResult = await pushgateway.pushAdd(pushAddArgs)
     const pushAddResponse = /** @type {import('http').IncomingMessage} */ (

--- a/packages/cron/src/jobs/measureNftTimeToRetrievability.js
+++ b/packages/cron/src/jobs/measureNftTimeToRetrievability.js
@@ -324,7 +324,14 @@ export function createPromClientRetrievalMetricsLogger(
     const pushAddArgs = {
       jobName: metricsPushGatewayJobName,
     }
-    await pushgateway.pushAdd(pushAddArgs)
+    const pushAddResult = await pushgateway.pushAdd(pushAddArgs)
+    const pushAddResponse = /** @type {import('http').IncomingMessage} */ (
+      pushAddResult.resp
+    )
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const pushAddRequest = /** @type {import('http').ClientRequest} */ (
+      /** @type {any} */ (pushAddResponse).req
+    )
     options.console.debug({
       type: 'metricPushed',
       metric: {
@@ -334,6 +341,16 @@ export function createPromClientRetrievalMetricsLogger(
         value,
       },
       pushgateway: pushAddArgs,
+      request: {
+        url: new URL(
+          `${pushAddRequest.protocol}//${String(
+            pushAddRequest.getHeader('host')
+          )}${pushAddRequest.path}`
+        ).toString(),
+      },
+      response: {
+        status: pushAddResponse.statusCode,
+      },
     })
   }
   return push

--- a/packages/cron/src/jobs/measureNftTimeToRetrievability.spec.js
+++ b/packages/cron/src/jobs/measureNftTimeToRetrievability.spec.js
@@ -83,6 +83,9 @@ test('createPromClientRetrievalMetricsLogger', async (t) => {
   const metric = createRetrievalDurationMetric(registry)
   const metricsPushGatewayJobName =
     'test-job-createPromClientRetrievalMetricsLogger'
+  const metricLabels = {
+    instance: 'instance-createPromClientRetrievalMetricsLogger',
+  }
   const pushGatewayAuthorization = 'bearer fake-auth'
   /** @type {import('http').IncomingMessage[]} */
   const fakePushGatewayRequests = []
@@ -108,6 +111,7 @@ test('createPromClientRetrievalMetricsLogger', async (t) => {
       registry,
       metric,
       metricsPushGatewayJobName,
+      metricLabels,
       pushGatewayUrl,
       pushGatewayAuthorization
     )
@@ -115,5 +119,13 @@ test('createPromClientRetrievalMetricsLogger', async (t) => {
   })
   t.is(fakePushGatewayRequests.length, 1)
   const [firstRequest] = fakePushGatewayRequests
-  t.is(firstRequest.url, `/metrics/job/${metricsPushGatewayJobName}`)
+  t.assert(
+    firstRequest.url?.startsWith(`/metrics/job/${metricsPushGatewayJobName}`)
+  )
+  for (const [label, value] of Object.entries(metricLabels)) {
+    t.assert(
+      firstRequest.url?.includes([label, value].join('/')),
+      `expected metric push request url to contain label '${label}'`
+    )
+  }
 })

--- a/packages/cron/src/lib/http.js
+++ b/packages/cron/src/lib/http.js
@@ -1,0 +1,43 @@
+import * as nodeHttp from 'http'
+
+/**
+ * Spin up an http server on an unused port, do some work with it, then shut it down.
+ * @param {import('http').RequestListener} listener
+ * @param {(baseUrl: URL) => Promise<void>} useServer
+ * @returns
+ */
+export async function withHttpServer(listener, useServer) {
+  const httpServer = nodeHttp.createServer(listener)
+  // listen on unused port
+  await new Promise((resolve, _reject) => {
+    httpServer.listen(0, () => {
+      resolve(true)
+    })
+  })
+  const baseUrl = addressUrl(httpServer.address())
+  if (!baseUrl) {
+    throw new Error(`failed to determine baseUrl from server`)
+  }
+  try {
+    await useServer(baseUrl)
+  } finally {
+    await new Promise((resolve, _reject) => {
+      httpServer.close(resolve)
+    })
+  }
+}
+
+/**
+ * Given return type of node http Server#address, return a URL descriving the server address
+ * @param {string|null|import('net').AddressInfo} addressInfo
+ * @returns {URL}
+ */
+export function addressUrl(addressInfo) {
+  if (addressInfo === null)
+    throw new TypeError('addressInfo is unexpectedly null')
+  if (typeof addressInfo === 'string') return new URL(addressInfo)
+  const { address, port } = addressInfo
+  const host = address === '::' ? '127.0.0.1' : address
+  const urlString = `http://${host}:${port}`
+  return new URL(urlString)
+}

--- a/packages/cron/src/lib/http.js
+++ b/packages/cron/src/lib/http.js
@@ -9,7 +9,7 @@ import * as nodeHttp from 'http'
 export async function withHttpServer(listener, useServer) {
   const httpServer = nodeHttp.createServer(listener)
   // listen on unused port
-  await new Promise((resolve, _reject) => {
+  await new Promise((resolve) => {
     httpServer.listen(0, () => {
       resolve(true)
     })
@@ -21,7 +21,7 @@ export async function withHttpServer(listener, useServer) {
   try {
     await useServer(baseUrl)
   } finally {
-    await new Promise((resolve, _reject) => {
+    await new Promise((resolve) => {
       httpServer.close(resolve)
     })
   }


### PR DESCRIPTION
Motivation
* add logging to nft-ttr job to easily see what the request url and response status code of the pushgateway request is (e.g. in case the current setup does not lead to 200 ok)
* this instance label consistent with other uses of prom/pushgateway and helps at query time later
* @alanshaw encouraged me to
* also adds a test ensuring that a mocked pushgateway receives an http request as expected 