### PR TITLE
feat: abortable API method calls

### DIFF
--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -94,11 +94,11 @@ export interface API {
    * will be transformed into a URL that looks like
    * `ipfs://bafy...hash/image/blob`.
    */
-  store<T extends TokenInput>(service: Service, token: T): Promise<Token<T>>
+  store<T extends TokenInput>(service: Service, token: T, options?: RequestOptions): Promise<Token<T>>
   /**
    * Stores a single file and returns it's CID.
    */
-  storeBlob(service: Service, content: Blob | File): Promise<CIDString>
+  storeBlob(service: Service, content: Blob | File, options?: RequestOptions): Promise<CIDString>
   /**
    * Stores a CAR file and returns it's root CID.
    */
@@ -112,25 +112,32 @@ export interface API {
    * be within the same directory, otherwise error is raised e.g. `foo/bar.png`,
    * `foo/bla/baz.json` is ok but `foo/bar.png`, `bla/baz.json` is not.
    */
-  storeDirectory(service: Service, files: FilesSource): Promise<CIDString>
+  storeDirectory(service: Service, files: FilesSource, options?: RequestOptions): Promise<CIDString>
   /**
    * Returns current status of the stored NFT by its CID. Note the NFT must
    * have previously been stored by this account.
    */
-  status(service: Service, cid: string): Promise<StatusResult>
+  status(service: Service, cid: string, options?: RequestOptions): Promise<StatusResult>
   /**
    * Removes stored content by its CID from this account. Please note that
    * even if content is removed from the service other nodes that have
    * replicated it might still continue providing it.
    */
-  delete(service: Service, cid: string): Promise<void>
+  delete(service: Service, cid: string, options?: RequestOptions): Promise<void>
   /**
    * Check if a CID of an NFT is being stored by NFT.Storage.
    */
-  check(service: PublicService, cid: string): Promise<CheckResult>
+  check(service: PublicService, cid: string, options?: RequestOptions): Promise<CheckResult>
 }
 
-export interface CarStorerOptions {
+export interface RequestOptions {
+  /**
+   * A signal that can be used to abort the request.
+   */
+  signal?: AbortSignal
+}
+
+export interface CarStorerOptions extends RequestOptions {
   /**
    * Callback called after each chunk of data has been uploaded. By default,
    * data is split into chunks of around 10MB. It is passed the actual chunk

--- a/packages/client/test/lib.spec.js
+++ b/packages/client/test/lib.spec.js
@@ -91,6 +91,21 @@ describe('client', () => {
         assert.match(error.message, /provide some content/)
       }
     })
+
+    it('aborts', async () => {
+      const client = new NFTStorage({ token, endpoint })
+      const controller = new AbortController()
+      controller.abort()
+      try {
+        await client.storeBlob(new Blob(['data']), {
+          signal: controller.signal,
+        })
+        assert.unreachable('request should not have succeeded')
+      } catch (err) {
+        const error = /** @type {Error} */ (err)
+        assert.equal(error.name, 'AbortError')
+      }
+    })
   })
 
   describe('upload car', () => {
@@ -190,6 +205,23 @@ describe('client', () => {
         const error = /** @type {Error} */ (err)
         assert.ok(error instanceof Error)
         assert.is(error.message, 'throwing an error for tests')
+      }
+    })
+
+    it('aborts', async () => {
+      const client = new NFTStorage({ token, endpoint })
+      const bytes = new TextEncoder().encode('data')
+      const hash = await sha256.digest(bytes)
+      const cid = CID.create(1, raw.code, hash)
+      const carReader = new CarReader(1, [cid], [{ cid, bytes }])
+      const controller = new AbortController()
+      controller.abort()
+      try {
+        await client.storeCar(carReader, { signal: controller.signal })
+        assert.unreachable('request should not have succeeded')
+      } catch (err) {
+        const error = /** @type {Error} */ (err)
+        assert.equal(error.name, 'AbortError')
       }
     })
   })
@@ -328,6 +360,21 @@ describe('client', () => {
         const error = /** @type {Error} */ (err)
         assert.ok(error instanceof Error)
         assert.match(error.message, /Unauthorized/)
+      }
+    })
+
+    it('aborts', async () => {
+      const client = new NFTStorage({ token, endpoint })
+      const controller = new AbortController()
+      controller.abort()
+      try {
+        await client.storeDirectory([new File(['data'], 'foo.txt')], {
+          signal: controller.signal,
+        })
+        assert.unreachable('request should not have succeeded')
+      } catch (err) {
+        const error = /** @type {Error} */ (err)
+        assert.equal(error.name, 'AbortError')
       }
     })
   })
@@ -584,6 +631,26 @@ describe('client', () => {
       assert.ok(result.data.animation_url instanceof URL)
       assert.ok(result.data.animation_url.protocol, 'ipfs:')
     })
+
+    it('aborts', async () => {
+      const client = new NFTStorage({ token, endpoint })
+      const controller = new AbortController()
+      controller.abort()
+      try {
+        await client.store(
+          {
+            name: 'name',
+            description: 'stuff',
+            image: new File(['fake image'], 'cat.png', { type: 'image/png' }),
+          },
+          { signal: controller.signal }
+        )
+        assert.unreachable('request should not have succeeded')
+      } catch (err) {
+        const error = /** @type {Error} */ (err)
+        assert.equal(error.name, 'AbortError')
+      }
+    })
   })
 
   describe('status', () => {
@@ -685,6 +752,20 @@ describe('client', () => {
         },
       ])
     })
+
+    it('aborts', async () => {
+      const client = new NFTStorage({ token, endpoint })
+      const controller = new AbortController()
+      controller.abort()
+      const cid = 'bafyreigdcnuc6w7stviim6a5m7uwqdw6p3z5zrqr22xt3num3ozra4ciqi'
+      try {
+        await client.status(cid, { signal: controller.signal })
+        assert.unreachable('request should not have succeeded')
+      } catch (err) {
+        const error = /** @type {Error} */ (err)
+        assert.equal(error.name, 'AbortError')
+      }
+    })
   })
 
   describe('delete', () => {
@@ -736,6 +817,20 @@ describe('client', () => {
         assert.is(error.message, 'missing token')
       }
     })
+
+    it('aborts', async () => {
+      const client = new NFTStorage({ token, endpoint })
+      const controller = new AbortController()
+      controller.abort()
+      const cid = 'bafyreigdcnuc6w7stviim6a5m7uwqdw6p3z5zrqr22xt3num3ozra4ciqi'
+      try {
+        await client.delete(cid, { signal: controller.signal })
+        assert.unreachable('request should not have succeeded')
+      } catch (err) {
+        const error = /** @type {Error} */ (err)
+        assert.equal(error.name, 'AbortError')
+      }
+    })
   })
 
   describe('check', () => {
@@ -770,6 +865,20 @@ describe('client', () => {
       } catch (err) {
         const error = /** @type {Error} */ (err)
         assert.ok(error.message.match(/not found/))
+      }
+    })
+
+    it('aborts', async () => {
+      const client = new NFTStorage({ token, endpoint })
+      const controller = new AbortController()
+      controller.abort()
+      const cid = 'bafyreigdcnuc6w7stviim6a5m7uwqdw6p3z5zrqr22xt3num3ozra4ciqi'
+      try {
+        await client.check(cid, { signal: controller.signal })
+        assert.unreachable('request should not have succeeded')
+      } catch (err) {
+        const error = /** @type {Error} */ (err)
+        assert.equal(error.name, 'AbortError')
       }
     })
   })


### PR DESCRIPTION
Adds `signal` (an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)) as an optional parameter to methods that call the API.

resolves #1973