### PR TITLE
added the package json to exports as it was causing trouble in react …

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,6 +13,7 @@
     "dist/bundle*"
   ],
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "browser": "./src/lib.js",
       "require": "./dist/src/lib.cjs",


### PR DESCRIPTION
I have got this issue several times in my react-native app while using this package. So, I added the path in my package.json exports to make it work.

_warn Package nft.storage has been ignored because it contains invalid configuration. Reason: Package subpath './package.json' is not defined by "exports" in /Volumes/workplace/www/_sandyapps/blockchain/qdex/mobile/node_modules/nft.storage/package.json_