### PR TITLE
fix: check for token blocked

### DIFF
--- a/packages/api/src/utils/db-client.js
+++ b/packages/api/src/utils/db-client.js
@@ -141,13 +141,16 @@ export class DBClient {
       .select('status')
       .eq('auth_key_id', key.id)
       .filter('deleted_at', 'is', null)
-      .single()
 
     if (error) {
       throw new DBError(error)
     }
 
-    return data?.status === 'Blocked'
+    if (!data || !data.length) {
+      return false
+    }
+
+    return data[0].status === 'Blocked'
   }
 
   /**


### PR DESCRIPTION
`.single()` throws if no results are returned, but it is likely to not return any rows if the token has not been blocked.

<img width="1249" alt="Screenshot 2022-07-01 at 15 24 33" src="https://user-images.githubusercontent.com/152863/176913314-393741af-c46e-4492-8676-8a0dd155cff4.png">
