### PR TITLE
wip: router changes to allow method-not-allowed

### DIFF
--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -124,7 +124,9 @@ r.add(
 // Upload
 r.add('get', '/check/:cid', withMode(nftCheck, RO), [postCors])
 r.add('get', '', withAuth(withMode(nftList, RO)), [postCors])
-r.add('get', '/:cid', withAuth(withMode(nftGet, RO)), [postCors])
+r.add('get', /^\/(?<cid>ba\S+|Qm\S+)/i, withAuth(withMode(nftGet, RO)), [
+  postCors,
+])
 r.add(
   'post',
   '/upload',

--- a/packages/api/test/auth.spec.js
+++ b/packages/api/test/auth.spec.js
@@ -1,0 +1,20 @@
+import assert from 'assert'
+
+describe.only('auth', () => {
+  it('should return 401 Unauthorized when auth header missing', async () => {
+    const res = await fetch('/login', { method: 'POST' })
+    assert.strictEqual(res.status, 401)
+    const { ok, error } = await res.json()
+    assert.strictEqual(ok, false)
+    assert.strictEqual(error.code, 'EXPECTED_BEARER_STRING')
+  })
+
+  it.only('should return 405 Method Not Allowed when not POST', async () => {
+    const res = await fetch('/login', { method: 'GET' })
+    assert.strictEqual(res.status, 405)
+    const { ok, error } = await res.json()
+    assert.strictEqual(ok, false)
+    // assert.strictEqual(error.code, 'EXPECTED_BEARER_STRING')
+    // QmVKaJVFaeeMSPonPSH1GK1Hxd82uXbroBbEsd9BRJARtc
+  })
+})


### PR DESCRIPTION
add tests for
- GET /login to return 405 Method Not Allowed
- POST /login to return 401 Unauthorized if auth header not present

initial work on getting router to find path-but-not-method matches

hampered by the `GET /:cid` route matching `GET /login`

see #2066

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>