### PR TITLE
fix: add missing dep it-pipe

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -59,6 +59,7 @@
     "@web-std/form-data": "^3.0.0",
     "carbites": "^1.0.6",
     "ipfs-car": "^0.6.2",
+    "it-pipe": "^1.1.0",
     "multiformats": "^9.6.4",
     "p-retry": "^4.6.1",
     "streaming-iterables": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16424,15 +16424,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.5.1, prettier@^2.5.1:
+prettier@2.5.1, "prettier@>=2.2.1 <=2.3.0", prettier@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
   integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
-
-"prettier@>=2.2.1 <=2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
-  integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
 
 pretty-error@^2.1.1:
   version "2.1.2"
@@ -19588,12 +19583,7 @@ typedoc@^0.22.14:
     minimatch "^5.1.0"
     shiki "^0.10.1"
 
-typescript@4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
-
-typescript@4.5.3:
+typescript@4.4.4, typescript@4.5.3:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
   integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==


### PR DESCRIPTION
Added in https://github.com/nftstorage/nft.storage/commit/27394f6435ebfbead8cad609b2e92be4b69b4661 but not added to dependencies.

v2 does not have a default export and causes issues like https://github.com/nftstorage/nft.storage/issues/2069 when used by folks using that version in their projects.

v1.1.0 is currently the version used by `ipfs-car`.

resolves https://github.com/nftstorage/nft.storage/issues/2069