### PR TITLE
feat!: rate limiting by ucan agent did

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,7 +31,7 @@
     "nanoid": "^3.1.30",
     "regexparam": "^2.0.0",
     "toucan-js": "^2.4.1",
-    "ucan-storage": "^ 1.3.0",
+    "ucan-storage": "^1.3.0",
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "NFT Storage API",
   "private": true,
   "type": "module",
@@ -31,7 +31,7 @@
     "nanoid": "^3.1.30",
     "regexparam": "^2.0.0",
     "toucan-js": "^2.4.1",
-    "ucan-storage": "^1.0.0",
+    "ucan-storage": "^ 1.3.0",
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "3.0.2",
+  "version": "3.0.1",
   "description": "NFT Storage API",
   "private": true,
   "type": "module",

--- a/packages/api/src/errors.js
+++ b/packages/api/src/errors.js
@@ -243,3 +243,20 @@ export class ErrorDIDNotFound extends HTTPError {
   }
 }
 ErrorMaintenance.CODE = 'ERROR_DID_NOT_FOUND'
+
+export class ErrorAgentDIDRequired extends HTTPError {
+  constructor(
+    msg = 'UCAN authorized request must be supplied with x-agent-did header set to the DID of the UCAN issuer',
+    status = 401
+  ) {
+    super(msg, status)
+    this.name = 'ErrorAgentDIDRequired'
+    this.code = ErrorUnauthenticated.CODE
+  }
+}
+
+export class ErrorInvalidRoute extends HTTPError {
+  constructor(msg = 'Invalid route for the request', status = 400) {
+    super(msg, status)
+  }
+}

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -130,6 +130,14 @@ r.add(
   '/upload',
   withAuth(withMode(nftUpload, RW), {
     checkHasAccountRestriction,
+  }),
+  [postCors]
+)
+r.add(
+  'post',
+  '/ucan-upload',
+  withAuth(withMode(nftUpload, RW), {
+    checkHasAccountRestriction,
     checkUcan,
   }),
   [postCors]

--- a/packages/api/test/nfts-upload.spec.js
+++ b/packages/api/test/nfts-upload.spec.js
@@ -498,7 +498,7 @@ describe('NFT Upload ', () => {
       assert.equal(res.status, 400)
       const { ok, error } = await res.json()
       assert.equal(ok, false)
-      assert.match(error.message, /Invalid route/)
+      assert.ok(error.message.match(/Invalid route/))
     }
 
     {
@@ -511,7 +511,7 @@ describe('NFT Upload ', () => {
       assert.equal(res.status, 401)
       const { ok, error } = await res.json()
       assert.equal(ok, false)
-      assert.match(error.message, /x-agent-did/)
+      assert.ok(error.message.match(/x-agent-did/))
     }
 
     {
@@ -528,7 +528,9 @@ describe('NFT Upload ', () => {
       assert.equal(res.status, 401)
       const { ok, error } = await res.json()
       assert.equal(ok, false)
-      assert.match(error.message, /Expected x-agent-did to be UCAN issuer DID/)
+      assert.ok(
+        error.message.match(/Expected x-agent-did to be UCAN issuer DID/)
+      )
     }
 
     const res = await fetch('ucan-upload', {

--- a/packages/api/test/nfts-upload.spec.js
+++ b/packages/api/test/nfts-upload.spec.js
@@ -488,11 +488,55 @@ describe('NFT Upload ', () => {
     const file = new Blob(['hello world!'], { type: 'application/text' })
     // expected CID for the above data
     const cid = 'bafkreidvbhs33ighmljlvr7zbv2ywwzcmp5adtf4kqvlly67cy56bdtmve'
-    const res = await fetch('upload', {
+    {
+      const res = await fetch('upload', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${opUcan}` },
+        body: file,
+      })
+
+      assert.equal(res.status, 400)
+      const { ok, error } = await res.json()
+      assert.equal(ok, false)
+      assert.match(error.message, /Invalid route/)
+    }
+
+    {
+      const res = await fetch('ucan-upload', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${opUcan}` },
+        body: file,
+      })
+
+      assert.equal(res.status, 401)
+      const { ok, error } = await res.json()
+      assert.equal(ok, false)
+      assert.match(error.message, /x-agent-did/)
+    }
+
+    {
+      const badkp = await KeyPair.create()
+      const res = await fetch('ucan-upload', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${opUcan}`,
+          'x-agent-did': badkp.did(),
+        },
+        body: file,
+      })
+
+      assert.equal(res.status, 401)
+      const { ok, error } = await res.json()
+      assert.equal(ok, false)
+      assert.match(error.message, /Expected x-agent-did to be UCAN issuer DID/)
+    }
+
+    const res = await fetch('ucan-upload', {
       method: 'POST',
-      headers: { Authorization: `Bearer ${opUcan}` },
+      headers: { Authorization: `Bearer ${opUcan}`, 'x-agent-did': kp.did() },
       body: file,
     })
+
     const { ok, value } = await res.json()
     assert(ok, 'Server response payload has `ok` property')
 

--- a/packages/website/pages/docs/how-to/ucan.md
+++ b/packages/website/pages/docs/how-to/ucan.md
@@ -153,6 +153,10 @@ Send a `GET` request to `https://api.nft.storage/did`, which should return a JSO
 
 The `value` field contains the service DID, which is used when [creating request tokens][ucan-storage-typedoc-creating-a-request-token].
 
+## Sending requests
+
+You can send upload requests with UCAN auth token to `https://api.nft.storage/ucan-upload` endpoint. Requests to that endpoint must have additional `x-agent-did` HTTP header with a value set to a DID token was issued/signed by.
+
 ## Getting help
 
 Use of UCANs to delegate upload permissions in NFT.Storage is currently a Preview Feature. If you find issues with the integration, need help with tooling, or have suggestions for improving the API for your use cases, please leave feedback in [this Github Discussion](https://github.com/nftstorage/nft.storage/discussions/1591). We're excited to see what you'll build!

--- a/packages/website/public/schema.yml
+++ b/packages/website/public/schema.yml
@@ -184,6 +184,55 @@ paths:
           $ref: '#/components/responses/forbidden'
         '500':
           $ref: '#/components/responses/internalServerError'
+  /ucan-upload:
+    post:
+      tags:
+        - NFT Storage
+      summary: Store a file
+      description: |
+        Just like `/upload` endpoint but [using UCAN authorization tokens](https://nft.storage/docs/how-to/ucan/#using-ucans-with-nftstorage).
+        You must set `x-agent-did` header to a DID that signed the token.
+
+      operationId: ucan-upload
+      requestBody:
+        required: true
+        content:
+          image/*:
+            schema:
+              type: string
+              format: binary
+          application/car:
+            schema:
+              type: string
+              format: binary
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+          '*/*':
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: OK
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/UploadResponse'
+        '400':
+          $ref: '#/components/responses/badRequest'
+        '401':
+          $ref: '#/components/responses/unauthorized'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '500':
+          $ref: '#/components/responses/internalServerError'
   /:
     get:
       tags:

--- a/yarn.lock
+++ b/yarn.lock
@@ -19586,10 +19586,10 @@ ua-parser-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.2.tgz#e2976c34dbfb30b15d2c300b2a53eac87c57a775"
   integrity sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==
 
-ucan-storage@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ucan-storage/-/ucan-storage-1.2.0.tgz#fa3899e86842cd6d832436303254512ee782a791"
-  integrity sha512-h3lDsuDVrKhgL8DBEMb1Fub+jvqp7jlOXJUaOTaKE5eXCG5IQZ1eol0YWOScSpjxOvpRwoYGNhEIZR0sb6DJaw==
+"ucan-storage@^ 1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ucan-storage/-/ucan-storage-1.3.0.tgz#b9f3e29fa77da22a636ba5d917f4e747da0a89c8"
+  integrity sha512-C1PvShqWTg6JzcBAuWDeCsaL6AggwsGWqbvKZ8XdN9csAukQVnA5/kerddhdPrpeoCGnJFfSkvBcPklZzdJ+OQ==
   dependencies:
     "@noble/ed25519" "^1.5.2"
     base-x "^4.0.0"


### PR DESCRIPTION
fixes https://github.com/nftstorage/nft.storage/issues/2092 

As per discussion today this changes ucan authorized request route to `/ucan-upload` and requires `x-agent-did` header to apply apply rate limiting.