### PR TITLE
fix: website workflow release build

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -67,11 +67,10 @@ jobs:
         with:
           name: ${{ matrix.browser }}-${{ matrix.os }}-test-results
           path: ${{ matrix.test_results_path }}
-  release:
+  changelog:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Release
+    name: Changelog
     runs-on: ubuntu-latest
-    needs: check
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v3
         id: tag-release
@@ -81,17 +80,35 @@ jobs:
           release-type: node
           monorepo-tags: true
           package-name: website
+  release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changelog.outputs.releases_created
+    name: Release
+    runs-on: ubuntu-latest
+    needs:
+      - check
+      - test-e2e
+      - changelog
+    steps:
       - uses: actions/checkout@v2
-        if: ${{ steps.tag-release.outputs.releases_created }}
       - uses: actions/setup-node@v2
-        if: ${{ steps.tag-release.outputs.releases_created }}
         with:
           node-version: '16'
           registry-url: https://registry.npmjs.org/
       - uses: bahmutov/npm-install@v1
-        if: ${{ steps.tag-release.outputs.releases_created }}
+      - name: Run build
+        env:
+          NEXT_PUBLIC_MAGIC: ${{ secrets.NEXT_PUBLIC_MAGIC }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+          NEXT_PUBLIC_COUNTLY_KEY: ${{ secrets.NEXT_PUBLIC_COUNTLY_KEY }}
+          NEXT_PUBLIC_COUNTLY_URL: ${{ secrets.NEXT_PUBLIC_COUNTLY_URL }}
+          NEXT_PUBLIC_ENV: production
+          NEXT_PUBLIC_API: https://api.nft.storage
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_TOKEN }}
+          SENTRY_ORG: protocol-labs-it
+          SENTRY_PROJECT: frontend
+          SENTRY_URL: https://sentry.io/
+        run: yarn build:website
       - name: Website - Deploy
-        if: ${{ steps.tag-release.outputs.releases_created }}
         run: npx wrangler pages publish --project-name nft-storage --branch main ./packages/website/out
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}


### PR DESCRIPTION
This PR fixes website workflow build. Automatic build is now disabled in CF, and as a result we need the ENV variables to be specified in the build here instead of tied with CF Dashboard