### PR TITLE
fix: fdw fault tolerance

### DIFF
--- a/packages/api/src/utils/db-client.js
+++ b/packages/api/src/utils/db-client.js
@@ -498,25 +498,29 @@ export class DBClient {
    * @param {string[]} cids
    */
   async getDealsForCids(cids = []) {
-    const rsp = await this.client.rpc('find_deals_by_content_cids', {
-      cids,
-    })
-    if (rsp.error) {
+    try {
+      const rsp = await this.client.rpc('find_deals_by_content_cids', {
+        cids,
+      })
+      if (rsp.error) {
+        throw new DBError(rsp.error)
+      }
+
+      /** @type {Record<string, import('./../bindings').Deal[]>} */
+      const result = {}
+      for (const d of rsp.data) {
+        const { contentCid: cid, ...rest } = d
+        if (!Array.isArray(result[cid])) {
+          result[cid] = [rest]
+        } else {
+          result[cid].push(rest)
+        }
+      }
+
+      return result
+    } catch (err) {
       return {}
     }
-
-    /** @type {Record<string, import('./../bindings').Deal[]>} */
-    const result = {}
-    for (const d of rsp.data) {
-      const { contentCid: cid, ...rest } = d
-      if (!Array.isArray(result[cid])) {
-        result[cid] = [rest]
-      } else {
-        result[cid].push(rest)
-      }
-    }
-
-    return result
   }
 
   /**


### PR DESCRIPTION
We sometimes see request failures for calls to FDW. In this case we actually get sent back non-JSON data and our postgrest client fails to parse it and throws i.e. does not _return_ an error.

We're seeing this in the upload flow because we immediately request our upload after it has been created. Our database is not under load, but the FDW database seems to sometimes not be available.

This PR handles the case when the call to FDW fails with a thrown error _not_ a returned one.

499 is [H27 - Client Request Interrupted](https://devcenter.heroku.com/articles/error-codes#h27-client-request-interrupted):

<img width="1001" alt="Screenshot 2022-08-01 at 18 09 55" src="https://user-images.githubusercontent.com/152863/182205206-e00032a7-a1cb-4e63-b575-6f8b361f18bc.png">

Here is the error our client throws because it receives HTML:

<img width="766" alt="Screenshot 2022-08-01 at 18 10 23" src="https://user-images.githubusercontent.com/152863/182205362-9581c559-9768-4655-a5d3-5e2f8431b39c.png">

.