### PR TITLE
fix: always retry s3 upload

### DIFF
--- a/packages/api/src/utils/s3-uploader.js
+++ b/packages/api/src/utils/s3-uploader.js
@@ -106,6 +106,7 @@ export class S3Uploader {
         await this._s3.send(new PutObjectCommand(cmdParams))
       }
     } catch (/** @type {any} */ err) {
+      // @ts-ignore TS does not know about `cause` yet.
       throw new Error('Failed to upload CAR', { cause: err })
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14818,6 +14818,25 @@ nextra@^2.0.0-beta.5:
     remark-mdx-code-meta "^1.0.0"
     slash "^3.0.0"
 
+nft.storage@^6.0.0:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/nft.storage/-/nft.storage-6.4.1.tgz#262faa3ba67970cbdd48480aa048d96671c6ccb4"
+  integrity sha512-UwZ+QgDCr58X+vHN4BydqdB89M8Vaza+vkWR9RatC3rXuDfIyYE5T7oOV53tbiuhA8x5Yi56tlG3NI8wLfOO1A==
+  dependencies:
+    "@ipld/car" "^3.2.3"
+    "@ipld/dag-cbor" "^6.0.13"
+    "@web-std/blob" "^3.0.1"
+    "@web-std/fetch" "^3.0.3"
+    "@web-std/file" "^3.0.0"
+    "@web-std/form-data" "^3.0.0"
+    carbites "^1.0.6"
+    ipfs-car "^0.6.2"
+    it-pipe "^1.1.0"
+    multiformats "^9.6.4"
+    p-retry "^4.6.1"
+    streaming-iterables "^6.0.0"
+    throttled-queue "^2.1.2"
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -19758,7 +19777,7 @@ ua-parser-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.2.tgz#e2976c34dbfb30b15d2c300b2a53eac87c57a775"
   integrity sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==
 
-"ucan-storage@^ 1.3.0":
+ucan-storage@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ucan-storage/-/ucan-storage-1.3.0.tgz#b9f3e29fa77da22a636ba5d917f4e747da0a89c8"
   integrity sha512-C1PvShqWTg6JzcBAuWDeCsaL6AggwsGWqbvKZ8XdN9csAukQVnA5/kerddhdPrpeoCGnJFfSkvBcPklZzdJ+OQ==


### PR DESCRIPTION
We're seeing more and more of the following errors. My suspicion is that the S3 client is not (or no longer) returning an error with `name: 'BadDigest'`. This PR changes the behaviour here to just always retry a failed upload once and adds the thrown error as the `cause` of a new `Error` so that we can retain context here (since the stack in sentry is not helpful).

<img width="1113" alt="Screenshot 2022-08-02 at 11 35 02" src="https://user-images.githubusercontent.com/152863/182354756-198b2641-1969-43e0-95e0-844afb144858.png">
