### PR TITLE
fix: block navigation to authenticated routes

### DIFF
--- a/packages/website/lib/constants.js
+++ b/packages/website/lib/constants.js
@@ -20,8 +20,17 @@ if (globalThis.window) {
   }
 }
 
+const AUTHENTICATED_ROUTES = {
+  MANAGE: 'manage',
+  FILES: 'files',
+  NEW_FILE: 'new-file',
+  NEW_KEY: 'new-key',
+  PINNING_REQUEST: 'pinning-request',
+}
+
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {
+  AUTHENTICATED_ROUTES,
   API: API,
   MAGIC_TOKEN: MAGIC_TOKEN,
 }

--- a/packages/website/lib/magic.js
+++ b/packages/website/lib/magic.js
@@ -59,11 +59,15 @@ export async function isLoggedIn() {
  * Login with email
  *
  * @param {string} email
+ * @param {string} [redirectPath]
  */
-export async function loginEmail(email) {
+export async function loginEmail(email, redirectPath) {
   const didToken = await getMagic().auth.loginWithMagicLink({
     email: email,
-    redirectURI: new URL('/callback', window.location.origin).href,
+    redirectURI: new URL(
+      `/callback${redirectPath ? '/' + redirectPath : ''}`,
+      window.location.origin
+    ).href,
   })
 
   if (didToken) {
@@ -78,11 +82,15 @@ export async function loginEmail(email) {
  * Login with social
  *
  * @param {import('@magic-ext/oauth').OAuthProvider} provider
+ * @param {string} [redirectPath]
  */
-export async function loginSocial(provider) {
+export async function loginSocial(provider, redirectPath) {
   await getMagic().oauth.loginWithRedirect({
     provider,
-    redirectURI: new URL('/callback', window.location.origin).href,
+    redirectURI: new URL(
+      `/callback${redirectPath ? '/' + redirectPath : ''}`,
+      window.location.origin
+    ).href,
   })
 }
 

--- a/packages/website/pages/login.js
+++ b/packages/website/pages/login.js
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import Router from 'next/router'
+import { useRouter } from 'next/router'
 import { loginEmail, loginSocial } from '../lib/magic.js'
 import countly from '../lib/countly'
 import Button from '../components/button.js'
@@ -21,6 +21,11 @@ export default function Login() {
   const [errorMsg, setErrorMsg] = useState('')
   const [disabled, setDisabled] = useState(false)
   const [isRedirecting, setIsRedirecting] = useState(false)
+  const router = useRouter()
+  const returnPath =
+    typeof router.query.returnUrl === 'string'
+      ? router.query.returnUrl
+      : undefined
 
   /**
    * @param {import('react').ChangeEvent<HTMLFormElement>} e
@@ -32,9 +37,9 @@ export default function Login() {
     setDisabled(true)
 
     try {
-      await loginEmail(e.currentTarget.email.value)
+      await loginEmail(e.currentTarget.email.value, returnPath)
       await queryClient.invalidateQueries('magic-user')
-      Router.push('/files')
+      router.push(returnPath ?? '/files')
     } catch (/** @type {any} */ error) {
       setDisabled(false)
       console.error('An unexpected error happened occurred:', error)
@@ -55,7 +60,7 @@ export default function Login() {
             className="w-64"
             onClick={() => {
               setIsRedirecting(true)
-              loginSocial('github')
+              loginSocial('github', returnPath)
             }}
             tracking={{
               event: countly.events.LOGIN_CLICK,


### PR DESCRIPTION
If a user deep links to an authenticated route, these changes will navigate the user to the login page and after they log in they'll be redirected to their intended destination.