### PR TITLE
fix: add href to child a element

### DIFF
--- a/packages/website/components/link.js
+++ b/packages/website/components/link.js
@@ -3,7 +3,7 @@ import Link from 'next/link'
 
 /**
  * @param {Object} props
- * @param {object | string} props.href
+ * @param {any} props.href
  * @param {string} [props.className]
  * @param {number} [props.tabIndex]
  * @param {string} [props.id]
@@ -14,7 +14,7 @@ import Link from 'next/link'
 const WrappedLink = ({ tabIndex = 0, href = '', children, ...otherProps }) => (
   <Link href={href} {...otherProps}>
     <a
-      href="replace"
+      href={href.pathname || href}
       {...otherProps}
       tabIndex={tabIndex}
       onClick={otherProps.onClick}


### PR DESCRIPTION
fixes #2133 
This PR adds the href to the nested `<a>` element of the link element. While this will be replaced during client-side routing, it will be used when opening in new window or new tab.