### PR TITLE
feat: cron runs nft-ttr twice as often (every 15min)

### DIFF
--- a/.github/workflows/cron-nft-ttr.yml
+++ b/.github/workflows/cron-nft-ttr.yml
@@ -2,7 +2,7 @@ name: Measure NFT Time to Retrievability (nft-ttr)
 
 on:
   schedule:
-    - cron: '30 * * * *'
+    - cron: '*/15 * * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Motivation:
* I want to have more frequent metrics in grafana dashboard
* I want to verify that changing this is all that's required to increase metric frequency (it's possible the constraint is actually based on how often prometheus scrapes the pushgateway)