### PR TITLE
fix: duplicate key name

### DIFF
--- a/packages/api/src/utils/db-client.js
+++ b/packages/api/src/utils/db-client.js
@@ -525,6 +525,18 @@ export class DBClient {
     /** @type {PostgrestQueryBuilder<definitions['auth_key']>} */
     const query = this.client.from('auth_key')
 
+    const { data: dataExists } = await query
+      .select()
+      .match({
+        user_id: key.userId,
+        name: key.name,
+      })
+      .is('deleted_at', null)
+
+    if (dataExists?.length) {
+      throw new Error('Duplicate key name.')
+    }
+
     const { data, error } = await query
       .upsert({
         name: key.name,

--- a/packages/api/test/db-client.spec.js
+++ b/packages/api/test/db-client.spec.js
@@ -55,3 +55,39 @@ test.serial('getUser should list only active keys', async (t) => {
   t.is(keys.length, 3)
   t.is(keys[1].name, 'key1')
 })
+
+test.serial('createKey should not allow duplicates', async (t) => {
+  // Arrange
+  const client = await createClientWithUser(t)
+  const config = getTestServiceConfig(t)
+  const issuer1 = `did:eth:0x73573${Date.now()}`
+  const token1 = await signJWT(
+    {
+      sub: issuer1,
+      iss: 'nft-storage',
+      iat: Date.now(),
+      name: 'key1',
+    },
+    config.SALT
+  )
+  await client.client.createKey({
+    name: 'key1',
+    secret: token1,
+    userId: client.userId,
+  })
+  let threw = false
+
+  // Act
+  try {
+    await client.client.createKey({
+      name: 'key1',
+      secret: token1,
+      userId: client.userId,
+    })
+  } catch (e) {
+    threw = true
+  }
+
+  // Assert
+  t.true(threw)
+})

--- a/packages/website/pages/manage.js
+++ b/packages/website/pages/manage.js
@@ -99,6 +99,14 @@ export default function ManageKeys({ user }) {
     </Button>
   )
 
+  /**
+   * @param {string} keyName
+   * @param {number} keyIndex
+   */
+  const getButtonKey = (keyName, keyIndex) => {
+    return `${keyName}-${keyIndex}`
+  }
+
   return (
     <main className="bg-nsgreen grow">
       <div className="max-w-7xl mx-auto py-4 px-6 sm:px-16">
@@ -190,7 +198,7 @@ export default function ManageKeys({ user }) {
                         </td>
                         <td className="shrink-cell center-cell">
                           <Popover
-                            isOpen={isActionMenuOpen === t[0]}
+                            isOpen={isActionMenuOpen === getButtonKey(t[0], k)}
                             onClickOutside={(e) => {
                               if (e.currentTarget !== null) {
                                 if (
@@ -262,13 +270,15 @@ export default function ManageKeys({ user }) {
                             )}
                           >
                             <button
-                              onClick={() => setIsActionMenuOpen(t[0])}
+                              onClick={() =>
+                                setIsActionMenuOpen(getButtonKey(t[0], k))
+                              }
                               className={`${
-                                isActionMenuOpen === t[0]
+                                isActionMenuOpen === getButtonKey(t[0], k)
                                   ? 'actions-trigger--active'
                                   : ''
                               } btn small actions-trigger`}
-                              data-key={t[0]}
+                              data-key={getButtonKey(t[0], k)}
                             >
                               Actions
                             </button>


### PR DESCRIPTION
closes https://github.com/nftstorage/nft.storage/issues/2138

This includes 3 fixes each of which should fix the issue
1. Enable the fix the popup menus so they're distinct
2. Add a unique constraint to the database to prevent duplicates (this might be a bad idea if there are duplicates already in PROD)
3. Added logic to check if a duplicate already exists and message that in the API layer