### PR TITLE
fix: broken docs link

### DIFF
--- a/packages/website/pages/docs/concepts/car-files.md
+++ b/packages/website/pages/docs/concepts/car-files.md
@@ -353,6 +353,7 @@ You may already be using `dag-cbor` without knowing it! When using the client li
 
 
 
+[howto-store]: https://nft.storage/docs/how-to/mint-custom-metadata/
 [reference-client-library]: https://nftstorage.github.io/nft.storage/client/
 [reference-http-api]: https://nft.storage/api-docs/
 [github-ipfs-car]: https://github.com/web3-storage/ipfs-car


### PR DESCRIPTION
is this the best link for the broken link in the page?

![image](https://user-images.githubusercontent.com/11778450/187343201-1b2386c1-e53d-4364-99f2-e5fc934bedd1.png)
