### PR TITLE
fix: fix typescript nodenext resolution

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,16 +16,19 @@
     ".": {
       "browser": "./src/lib.js",
       "require": "./dist/src/lib.cjs",
+      "types": "./dist/src/lib.d.ts",
       "node": "./src/lib.js"
     },
     "./src/platform.js": {
       "browser": "./src/platform.web.js",
       "require": "./dist/src/platform.cjs",
+      "types": "./dist/src/platform.cjs",
       "node": "./src/platform.js"
     },
     "./src/token.js": {
       "browser": "./src/token.js",
       "require": "./dist/src/token.cjs",
+      "types": "./dist/src/token.cjs",
       "node": "./src/token.js"
     },
     "./dist/bundle.esm.min.js": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -22,13 +22,13 @@
     "./src/platform.js": {
       "browser": "./src/platform.web.js",
       "require": "./dist/src/platform.cjs",
-      "types": "./dist/src/platform.cjs",
+      "types": "./dist/src/platform.d.ts",
       "node": "./src/platform.js"
     },
     "./src/token.js": {
       "browser": "./src/token.js",
       "require": "./dist/src/token.cjs",
-      "types": "./dist/src/token.cjs",
+      "types": "./dist/src/token.d.ts",
       "node": "./src/token.js"
     },
     "./dist/bundle.esm.min.js": {


### PR DESCRIPTION
tiny fix here: while your ESModule build is working totally fine, when downstream consumers are set up to use `nodenext` for their `module` & `moduleResolution` settings, typescript reads your `package.json` and sees that the `exports.node` points to the `src` folder and tries to also look there for the typescript typings

as per [the typescript docs](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing) this just lets typescript know to still keep looking in the `dist/src` folder for the types :)