### PR TITLE
feat: redirect slash blog

### DIFF
--- a/packages/website/public/_redirects
+++ b/packages/website/public/_redirects
@@ -1,1 +1,3 @@
 /blog/post/* https://blog.nft.storage/posts/:splat 302
+/blog/ https://blog.nft.storage 302
+/blog https://blog.nft.storage 302


### PR DESCRIPTION
This PR adds a redirect for nft.storage/blog to the new blog.nft.storage site.