### PR TITLE
fix: docs with incorrect blocking duration due to rate limits

### DIFF
--- a/packages/website/pages/docs/concepts/gateways.md
+++ b/packages/website/pages/docs/concepts/gateways.md
@@ -50,7 +50,7 @@ You can avoid the redirect from path to subdomain URL by creating a [subdomain s
 
 IPFS gateways are a public, shared resource, and they are often in high demand. To provide equitable access to all users, the NFT.Storage gateway imposes request limits on high-volume traffic sources.
 
-The NFT.Storage gateway is currently rate limited to 200 requests per minute for a given IP address. In the event of a rate limit, the IP will be blocked for 30 seconds. 
+The NFT.Storage gateway is currently rate limited to 200 requests per minute for a given IP address. In the event of a rate limit, the IP will be blocked for a minute. 
 
 ## Types of gateway
 


### PR DESCRIPTION
I would to be 30 seconds (I think 🤔 ) but now CF Firewall does not allow blocking duration smaller than the interval using to track rate limit. In other words, if we say 200req/min we need to block in same time unit (i.e 60 seconds).

There were some thoughts on doing some changes to accomodate this, like 100req/30s but we might hit other issues and need to think about this more carefully - read more at https://github.com/nftstorage/nft.storage/issues/2202#issuecomment-1273543142

Closes https://github.com/nftstorage/nft.storage/issues/2202