### PR TITLE
chore: api Logging#setUser expects user.id as string instead of number

### DIFF
--- a/packages/api/src/utils/auth.js
+++ b/packages/api/src/utils/auth.js
@@ -52,7 +52,7 @@ export async function validate(event, { log, db, ucanService }, options) {
     }
     const user = await db.getUser(root.audience())
     if (user) {
-      log.setUser({ id: user.id })
+      log.setUser({ id: user.id.toString() })
       return {
         user: filterDeletedKeys(user),
         db,
@@ -83,7 +83,7 @@ export async function validate(event, { log, db, ucanService }, options) {
         }
 
         log.setUser({
-          id: user.id,
+          id: user.id.toString(),
         })
         return {
           user: filterDeletedKeys(user),
@@ -105,7 +105,7 @@ export async function validate(event, { log, db, ucanService }, options) {
     const user = await db.getUser(claim.iss)
     if (user) {
       log.setUser({
-        id: user.id,
+        id: user.id.toString(),
       })
 
       return {

--- a/packages/api/src/utils/logs.js
+++ b/packages/api/src/utils/logs.js
@@ -46,7 +46,7 @@ export class Logging {
     }
     this.metadata = {
       user: {
-        id: 0,
+        id: '0',
       },
       request: {
         url: request.url,
@@ -68,10 +68,10 @@ export class Logging {
    * Set user
    *
    * @param {Object} user
-   * @param {number} [user.id]
+   * @param {string} user.id
    */
   setUser(user) {
-    this.metadata.user.id = user.id || 0
+    this.metadata.user.id = user.id
     this.opts.sentry.setUser({
       id: `${user.id}`,
     })


### PR DESCRIPTION
Motivation:
* this way `Logging#setUser` can accomodate user ids that correspond to bigints
* avoid this mistake https://github.com/web3-storage/web3.storage/issues/2040

Related
* I noticed that the db-types user definition has `id: number`. I wonder if it should change to `bigint` or `text` (and underlying queries will need to change). https://github.com/nftstorage/nft.storage/blob/6fcd38923506965012505473b57afde2ce22973e/packages/api/src/utils/db-types.d.ts#L1188
  * nft.storage prod counter isn't at risk of bumping into this soon, but it is a bigint underneath so it could happen.
