### PR TITLE
ci: add w3s.link to nft-ttr cronjob

### DIFF
--- a/.github/workflows/cron-nft-ttr.yml
+++ b/.github/workflows/cron-nft-ttr.yml
@@ -34,6 +34,7 @@ jobs:
             --minImageSizeBytes=10000000 \
             --gateway https://nftstorage.link \
             --gateway https://dweb.link \
+            --gateway https://w3s.link \
             --metricsPushGateway $PUSHGATEWAY_URL \
             --metricsPushGatewayJobName $PUSHGATEWAY_JOBNAME \
             --metricsLabelsJson '{"instance": "github_action"}' \


### PR DESCRIPTION
Motivation:
* so we measure this gateway compared to others