### PR TITLE
fix: use dynamic title in head on docs pages

### DIFF
--- a/packages/website/theme.config.js
+++ b/packages/website/theme.config.js
@@ -9,11 +9,7 @@ const theme = {
   footer: false,
   header: false,
   logo: <></>,
-  head: (
-    <>
-      <title>NFT.Storage Docs</title>
-    </>
-  ),
+  titleSuffix: '',
 }
 
 export default theme


### PR DESCRIPTION
Previously it'd just display "NFT.Storage Docs" in the title tag on every docs page.  Now it'll update to match the h1 on the page:

![image](https://user-images.githubusercontent.com/99349687/218569342-6a6cfd1b-203a-4db4-a43d-dec5913638be.png)

partially fixes #2304 .  To get dynamic og tags it looks like we might have to upgrade nextra (which means also upgrading React and nextjs).