### PR TITLE
fix: include key in error message

### DIFF
--- a/packages/api/src/utils/uploader/r2-uploader.js
+++ b/packages/api/src/utils/uploader/r2-uploader.js
@@ -53,8 +53,7 @@ export class R2Uploader {
       ])
       return { key, url }
     } catch (cause) {
-      // @ts-expect-error wen ts understand Error object?
-      throw new Error('Failed to upload CAR to R2', { cause })
+      throw new Error(`Failed to upload CAR to R2: ${key}`, { cause })
     }
   }
 
@@ -73,8 +72,7 @@ export class R2Uploader {
         retries: 3,
       })
     } catch (cause) {
-      // @ts-expect-error error.cause is legit.
-      throw new Error('Failed to write satnav index to R2', { cause })
+      throw new Error(`Failed to write satnav index to R2: ${key}`, { cause })
     }
   }
 
@@ -90,8 +88,9 @@ export class R2Uploader {
         retries: 3,
       })
     } catch (cause) {
-      // @ts-expect-error error.cause is legit.
-      throw new Error('Failed to write dudewhere index to R2', { cause })
+      throw new Error(`Failed to write dudewhere index to R2: ${key}`, {
+        cause,
+      })
     }
   }
 }

--- a/packages/api/src/utils/uploader/r2-uploader.js
+++ b/packages/api/src/utils/uploader/r2-uploader.js
@@ -53,6 +53,7 @@ export class R2Uploader {
       ])
       return { key, url }
     } catch (cause) {
+      // @ts-expect-error wen ts understand Error object?
       throw new Error(`Failed to upload CAR to R2: ${key}`, { cause })
     }
   }
@@ -72,6 +73,7 @@ export class R2Uploader {
         retries: 3,
       })
     } catch (cause) {
+      // @ts-expect-error wen ts understand Error object?
       throw new Error(`Failed to write satnav index to R2: ${key}`, { cause })
     }
   }
@@ -88,6 +90,7 @@ export class R2Uploader {
         retries: 3,
       })
     } catch (cause) {
+      // @ts-expect-error wen ts understand Error object?
       throw new Error(`Failed to write dudewhere index to R2: ${key}`, {
         cause,
       })

--- a/packages/api/src/utils/uploader/r2-uploader.js
+++ b/packages/api/src/utils/uploader/r2-uploader.js
@@ -73,7 +73,7 @@ export class R2Uploader {
         retries: 3,
       })
     } catch (cause) {
-      // @ts-expect-error wen ts understand Error object?
+      // @ts-expect-error error.cause is legit.
       throw new Error(`Failed to write satnav index to R2: ${key}`, { cause })
     }
   }
@@ -90,7 +90,7 @@ export class R2Uploader {
         retries: 3,
       })
     } catch (cause) {
-      // @ts-expect-error wen ts understand Error object?
+      // @ts-expect-error error.cause is legit.
       throw new Error(`Failed to write dudewhere index to R2: ${key}`, {
         cause,
       })


### PR DESCRIPTION
Include the R2 key in the error message for better visibility when debugging.

We're getting rate limits for put with the same key...