### PR TITLE
fix: set client default chunk size to 50MB

### DIFF
--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -28,7 +28,7 @@ import pipe from 'it-pipe'
 
 const MAX_STORE_RETRIES = 5
 const MAX_CONCURRENT_UPLOADS = 3
-const MAX_CHUNK_SIZE = 1024 * 1024 * 10 // chunk to ~10MB CARs
+const MAX_CHUNK_SIZE = 1024 * 1024 * 50 // chunk to ~50MB CARs
 const RATE_LIMIT_REQUESTS = 30
 const RATE_LIMIT_PERIOD = 10 * 1000
 

--- a/packages/client/test/lib.spec.js
+++ b/packages/client/test/lib.spec.js
@@ -191,7 +191,7 @@ describe('client', () => {
           uploadedChunks++
         },
       })
-      assert.ok(uploadedChunks >= 12)
+      assert.ok(uploadedChunks >= 3)
       assert.equal(cid, expectedCid)
     })
 


### PR DESCRIPTION
Per talk async with @alanshaw , setting default chunk size to 50MB to save us 5x in number of indexes needed to write/read R2