### PR TITLE
feat: pins-add catches 400 from cluster and logs to sentry

### DIFF
--- a/packages/api/src/errors.js
+++ b/packages/api/src/errors.js
@@ -284,3 +284,20 @@ export class ErrorAgentDIDRequired extends HTTPError {
   }
 }
 ErrorAgentDIDRequired.CODE = 'ERROR_AGENT_DID_REQUIRED'
+
+/**
+ * indicates unexpected http error while trying to pin via http.
+ */
+export class PinHttpFailure extends Error {
+  /**
+   *
+   * @param {string} message
+   * @param {ErrorOptions} opts
+   * @param {string} [responseText] - http response text, if available, to aid debugging
+   */
+  constructor(message, opts, responseText) {
+    super(message, opts)
+    this.name = 'HttpFailure'
+    this.responseText = responseText
+  }
+}


### PR DESCRIPTION
Motivation:
* get `responseText` [in sentry so I can tell a bit more about what's going on](https://protocol-labs-it.sentry.io/issues/3226038374/?query=is%3Aunresolved&referrer=issue-stream)
* got a grafana alert about errors and I looked in sentry and there were 100+ in the last hour so figured this would give me more visibility next time it happens