### PR TITLE
feat: send `delegates` on pin add response

### DIFF
--- a/packages/api/src/routes/pins-add.js
+++ b/packages/api/src/routes/pins-add.js
@@ -46,9 +46,11 @@ export async function pinsAdd(event, ctx) {
     )
   }
 
-  await cluster.pin(cid.sourceCid, {
+  const pinRes = await cluster.pin(cid.sourceCid, {
     origins: pinData.origins,
   })
+
+  const delegates = pinRes?.metadata?.delegates
 
   const upload = await db.createUpload({
     pins: [
@@ -67,5 +69,6 @@ export async function pinsAdd(event, ctx) {
     name: pinData.name,
   })
 
-  return new JSONResponse(toPinsResponse(upload))
+  // @ts-expect-error cluster client types expect Record<string, string> but delegates is string[]
+  return new JSONResponse(toPinsResponse(upload, delegates))
 }

--- a/packages/api/src/utils/db-transforms.js
+++ b/packages/api/src/utils/db-transforms.js
@@ -44,8 +44,9 @@ export function toNFTResponse(upload, sourceCid) {
  * Transform db response into Pin response
  *
  * @param {import('./db-client-types').UploadOutput} upload
+ * @param {string[]} [delegates]
  */
-export function toPinsResponse(upload) {
+export function toPinsResponse(upload, delegates = []) {
   /** @type {import('../bindings').PinsResponse} */
   const rsp = {
     requestid: upload.source_cid,
@@ -57,7 +58,7 @@ export function toPinsResponse(upload) {
       name: upload.name,
       origins: upload.origins,
     },
-    delegates: cluster.delegates(),
+    delegates,
   }
   return rsp
 }


### PR DESCRIPTION
allows undialable nodes to connect to us when pinning via the pinning service api

see: https://github.com/web3-storage/web3.storage/pull/2255
see: https://github.com/web3-storage/pickup/pull/134

License: MIT