### PR TITLE
fix: deleted token error message

### DIFF
--- a/packages/api/src/utils/auth.js
+++ b/packages/api/src/utils/auth.js
@@ -78,7 +78,7 @@ export async function validate(event, { log, db, ucanService }, options) {
           if (isBlocked) {
             throw new ErrorTokenBlocked()
           } else {
-            throw new ErrorUserNotFound()
+            throw new ErrorTokenNotFound()
           }
         }
 


### PR DESCRIPTION
This fixes the (currently) confusing and surprisingly common case when a user deletes their API token and then receives the error "user not found" when trying to use the deleted key to upload. The error confusingly says their user is not found...when actually it should say token not found.

I believe this change captures the intention of the original code - that is, if the token is deleted but not blocked, then respond with a "token not found" error.