### PR TITLE
fix: dudewhere root cid should be content cid

### DIFF
--- a/packages/api/src/bindings.d.ts
+++ b/packages/api/src/bindings.d.ts
@@ -271,7 +271,8 @@ export type Backup = {
 // needs to be a type so it can be assigned to Record<string, string>
 export type BackupMetadata = {
   structure: DagStructure
-  rootCid: string
+  sourceCid: string
+  contentCid: string
   carCid: string
 }
 

--- a/packages/api/src/routes/nfts-upload.js
+++ b/packages/api/src/routes/nfts-upload.js
@@ -140,10 +140,12 @@ export async function uploadCarWithStat(
   stat
 ) {
   const sourceCid = stat.rootCid.toString()
+  const contentCid = stat.rootCid.toV1().toString()
   const carCid = await createCarCid(stat.carBytes)
   const metadata = {
     structure: stat.structure || 'Unknown',
-    rootCid: sourceCid,
+    sourceCid,
+    contentCid,
     carCid: carCid.toString(),
   }
 
@@ -171,7 +173,7 @@ export async function uploadCarWithStat(
   const upload = await ctx.db.createUpload({
     mime_type: mimeType,
     type: uploadType,
-    content_cid: stat.rootCid.toV1().toString(),
+    content_cid: contentCid,
     source_cid: sourceCid,
     dag_size: stat.size,
     user_id: user.id,

--- a/packages/api/src/utils/uploader/r2-uploader.js
+++ b/packages/api/src/utils/uploader/r2-uploader.js
@@ -48,7 +48,7 @@ export class R2Uploader {
     try {
       await pRetry(put, { retries: 3, onFailedAttempt: console.log })
       await Promise.all([
-        this.uploadDudeWhereLink(metadata.rootCid, carCid),
+        this.uploadDudeWhereLink(metadata.contentCid, carCid),
         this.uploadSatNavIndex(carBytes, carCid),
       ])
       return { key, url }

--- a/packages/api/src/utils/uploader/s3-uploader.js
+++ b/packages/api/src/utils/uploader/s3-uploader.js
@@ -67,7 +67,7 @@ export class S3Uploader {
    */
   async uploadCar(carBytes, carCid, userId, metadata) {
     const carHash = uint8ArrayToString(carCid.multihash.bytes, 'base32')
-    const key = `raw/${metadata.rootCid}/${this._appName}-${userId}/${carHash}.car`
+    const key = `raw/${metadata.sourceCid}/${this._appName}-${userId}/${carHash}.car`
     const url = new URL(key, this._baseUrl.toString())
 
     /** @type {import('@aws-sdk/client-s3').PutObjectCommandInput} */


### PR DESCRIPTION
there are a few entries in DUDEWHERE bucket with CIDv0. Example: https://dash.cloudflare.com/fffa4b4363a7e5250af8357087263b3a/r2/default/buckets/dudewhere-prod-0

This won't work with reading from freeway from w3s.link when we always redirect to CIDv1