### PR TITLE
Fix large file read

### DIFF
--- a/examples/client/node.js/storeBlob.js
+++ b/examples/client/node.js/storeBlob.js
@@ -19,5 +19,10 @@ async function main() {
     const status = await storage.status(cid)
     console.log(status)
   })
+  // on error will show what happened if something goes wrong
+  readStream.on('error', (error) => {
+    console.log({ error })
+  })
+
 }
 main()

--- a/examples/client/node.js/storeBlob.js
+++ b/examples/client/node.js/storeBlob.js
@@ -6,10 +6,18 @@ const token = 'API_KEY' // your API key from https://nft.storage/manage
 
 async function main() {
   const storage = new NFTStorage({ endpoint, token })
-  const data = await fs.promises.readFile('pinpie.jpg')
-  const cid = await storage.storeBlob(new Blob([data]))
-  console.log({ cid })
-  const status = await storage.status(cid)
-  console.log(status)
+  let data = ""
+  const readStream = fs.createReadStream('pinpie.jpg')
+  // on data will receive data from the stream and concatenate it to the variable data
+  readStream.on('data', (chunk) => {
+    data += chunk
+  })
+  // on end will finish the stream
+  readStream.on('end', async () => {
+    const cid = await storage.storeBlob(new Blob([data]))
+    console.log({ cid })
+    const status = await storage.status(cid)
+    console.log(status)
+  })
 }
 main()


### PR DESCRIPTION
Switched from simple fs.readfile to stream input.
Please mind that since the NFTStorage does not provide stream writing the client must have enough RAM to hold the entire file.
Maybe a partial write or stream must be applied to the NFTSTorage object as well