### PR TITLE
fix: OpenAPI Schema Issue for /upload Endpoint

### DIFF
--- a/packages/website/public/schema.yml
+++ b/packages/website/public/schema.yml
@@ -156,7 +156,7 @@ paths:
           schema:
             type: string
             format: DID
-            required: false
+          required: false
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Description
While trying to generate Rust code using the OpenAPI specification with the command `openapi-generator-cli generate -g rust -i docs/api.yml -o hoge`, I encountered the following validation error:

```
Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 1, Warning count: 1
Errors: 
        -attribute paths.'/upload'(post).parameters.[x-agent-did].schemas.required is not of type `array`
```

This PR aims to resolve this issue by correcting the schema definition for the `x-agent-did` parameter in the `/upload` endpoint.