### PR TITLE
fix: Deal model to include an optional lastChanged field

### DIFF
--- a/packages/website/public/schema.yml
+++ b/packages/website/public/schema.yml
@@ -472,7 +472,7 @@ components:
         batchRootCid:
           type: string
           example: bafkreidivzimqfqtoqxkrpge6bjyhlvxqs3rhe73owtmdulaxr5do5in7u
-        lastChange:
+        lastChanged:
           type: string
           example: '2021-03-18T11:46:50.000Z'
           description: 'This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: YYYY-MM-DDTHH:MM:SSZ.'
@@ -519,7 +519,6 @@ components:
           description: 'This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: YYYY-MM-DDTHH:MM:SSZ.'
       required:
         - status
-        - lastChange
     Date:
       type: string
       format: date-time


### PR DESCRIPTION
Upon actually making the API call, I received the following JSON as a response. It appears that `lastChanged` has been renamed and is no longer required.


```json
{
  "ok": true,
  "value": [
    {
      ......
      "deals": [
        {
          ........
          "lastChanged": null,
```