### PR TITLE
fix: enable `url_standard` compatbility flag

### DIFF
--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -11,6 +11,7 @@ compatibility_flags = [
    "formdata_parser_supports_files",
    "streams_enable_constructors",
    "transformstream_enable_standard_constructor",
+   "url_standard",
 ]
 no_bundle = true
 r2_buckets = [


### PR DESCRIPTION
We were running into an issue parsing the w3up UCAN.

It turns out that we rely on the platform's URL class to parse DIDs in @iplad/dag-ucan: https://github.com/ipld/js-dag-ucan/blob/21bae4e0ad7ff76e0c7b73938dcc228726854a43/src/schema.js#L136 that's a little quirky since DIDs are really URIs not URLs but it works! except....

Cloudflare's URL implementation is not spec compliant! https://developers.cloudflare.com/workers/runtime-apis/web-standards/#url-api

Critically, it only supports "URLs conforming to HTTP and HTTPS schemes" which, of course, DIDs do not.

So what was happening was this attempt to parse the UCAN was trying to parse as CBOR, failing and swallowing the error, and then falling back to JWT, which also failed, but it swallowed the original error: https://github.com/ipld/js-dag-ucan/blob/21bae4e0ad7ff76e0c7b73938dcc228726854a43/src/lib.js#L50

I did a little extra work to parse as CBOR in a context where the error wouldn't be thrown: https://github.com/nftstorage/nft.storage/pull/2536/files#diff-81e52ca70244fb599510375cb3757b01c7efda6d0c16a9b570fc49451eb08d17R71 and that finally gave me the confusing-but-ultimately-illuminating error "ParseError: Capability has invalid 'with: "did:key:z6M..."', value must be a valid URI string"

THE GOOD NEWS is that this is trivial to fix - Cloudflare has a url_standard compatibility flag that I've tested in staging and confirmed fixes this error:

https://github.com/nftstorage/nft.storage/pull/2537