### PR TITLE
feat: uploadCarWithStat avoids copying stat.carBytes via Blob construction

### DIFF
--- a/packages/api/src/routes/nfts-upload.js
+++ b/packages/api/src/routes/nfts-upload.js
@@ -178,7 +178,16 @@ export async function uploadCarWithStat(
     // should only be 1 - shard size in w3up is > max upload size in CF
     /** @type {import('@web3-storage/w3up-client/types').CARLink[]} */
     const shards = []
-    await w3up.uploadCAR(new Blob([stat.carBytes]), {
+    const carBytesBlobLike = {
+      stream: () =>
+        new ReadableStream({
+          start(c) {
+            c.enqueue(stat.carBytes)
+            c.close()
+          },
+        }),
+    }
+    await w3up.uploadCAR(carBytesBlobLike, {
       onShardStored: ({ cid }) => {
         shards.push(cid)
       },


### PR DESCRIPTION
… and instead wraps the stat.carBytes Uint8Array as a BlobLike

Context
* trying to make changes that help these code paths avoid the 'out of memory' others saw when testing on staging

Motivation:
* removing this `new Blob` could get rid of a memory allocation that could be contributing to 'out of memory'
* I think by passing a BlobLike to `uploadCAR` here and not a whole blob, there will not be downstream copies of the underlying bytes because this car BlobLike, once passed to `uploadCAR` will get passed to a `CAR.BlockStream` that streams out blocks without re-buffering the whole car bytes in memory https://github.com/web3-storage/w3up/blob/main/packages/upload-client/src/index.js#L107