### PR TITLE
feat(api): add count to list nfts api

### DIFF
--- a/packages/api/src/routes/nfts-list.js
+++ b/packages/api/src/routes/nfts-list.js
@@ -33,10 +33,13 @@ export async function nftList(event, ctx) {
     throw new HTTPError('invalid params', 400)
   }
 
-  const nfts = await db.listUploads(user.id, options)
+  const data = await db.listUploads(user.id, options)
 
-  return new JSONResponse({
-    ok: true,
-    value: nfts?.map((n) => toNFTResponse(n)),
-  })
+  return new JSONResponse(
+    {
+      ok: true,
+      value: data.uploads?.map((n) => toNFTResponse(n)),
+    },
+    data.count ? { headers: { Count: data.count.toString() } } : {}
+  )
 }

--- a/packages/api/src/routes/pins-list.js
+++ b/packages/api/src/routes/pins-list.js
@@ -45,7 +45,7 @@ export async function pinsList(event, ctx) {
     // Aggregate result into proper output
     let count = 0
     const results = []
-    for (const upload of data) {
+    for (const upload of data.uploads) {
       if (upload.content.pin.length > 0) {
         count++
         results.push(toPinsResponse(upload))

--- a/packages/api/src/utils/db-client.js
+++ b/packages/api/src/utils/db-client.js
@@ -373,7 +373,7 @@ export class DBClient {
     const from = this.client.from('upload')
     const match = opts.match || 'exact'
     let query = from
-      .select(this.uploadQuery)
+      .select(this.uploadQuery, { count: 'exact' })
       .eq('user_id', userId)
       .is('deleted_at', null)
       .filter(
@@ -422,7 +422,7 @@ export class DBClient {
       query = query.gte('inserted_at', opts.after)
     }
 
-    const { data: uploads, error } = await query
+    const { data: uploads, count, error } = await query
     if (error) {
       throw new DBError(error)
     }
@@ -431,12 +431,15 @@ export class DBClient {
 
     const deals = await this.getDealsFromDagcargoFDW(cids)
 
-    return uploads?.map((u) => {
-      return {
-        ...u,
-        deals: deals[u.content_cid] || [],
-      }
-    })
+    return {
+      count,
+      uploads: uploads?.map((u) => {
+        return {
+          ...u,
+          deals: deals[u.content_cid] || [],
+        }
+      }),
+    }
   }
 
   /**

--- a/packages/api/src/utils/json-response.js
+++ b/packages/api/src/utils/json-response.js
@@ -7,6 +7,7 @@ export class JSONResponse extends Response {
   constructor(body, init = {}) {
     const headers = {
       headers: {
+        ...init.headers,
         'content-type': 'application/json;charset=UTF-8',
       },
     }

--- a/packages/api/test/nfts-list.spec.js
+++ b/packages/api/test/nfts-list.spec.js
@@ -57,6 +57,7 @@ test.serial(
     const res = await mf.dispatchFetch('http://miniflare.test', {
       headers: { Authorization: `Bearer ${client.token}` },
     })
+    t.is(parseInt(res.headers.get('count') || ''), 2)
     const { ok, value } = await res.json()
 
     t.is(value[0].cid, cid2)
@@ -88,6 +89,7 @@ test.serial('should list 1 nft with param limit=1', async (t) => {
   const res = await mf.dispatchFetch('http://miniflare.test/?limit=1', {
     headers: { Authorization: `Bearer ${client.token}` },
   })
+  t.is(parseInt(res.headers.get('count') || ''), 2)
   const { ok, value } = await res.json()
 
   t.is(value.length, 1)
@@ -110,6 +112,7 @@ test.serial('should list the default 10 nfts with no params', async (t) => {
   const res = await mf.dispatchFetch('http://miniflare.test', {
     headers: { Authorization: `Bearer ${client.token}` },
   })
+  t.is(parseInt(res.headers.get('count') || ''), 10)
   const { ok, value } = await res.json()
 
   t.is(value.length, 10)
@@ -176,6 +179,8 @@ test.serial('should list only active nfts', async (t) => {
   const res = await mf.dispatchFetch('http://miniflare.test', {
     headers: { Authorization: `Bearer ${client.token}` },
   })
+  t.is(parseInt(res.headers.get('count') || ''), 1)
+
   const { ok, value } = await res.json()
 
   t.true(ok)
@@ -203,6 +208,7 @@ test.serial('should list nfts with their parts', async (t) => {
   const res = await mf.dispatchFetch('http://miniflare.test', {
     headers: { Authorization: `Bearer ${client.token}` },
   })
+  t.is(parseInt(res.headers.get('count') || ''), 1)
   const { ok, value } = await res.json()
 
   t.true(ok)
@@ -236,6 +242,7 @@ test.serial(
     const res = await mf.dispatchFetch('http://miniflare.test', {
       headers: { Authorization: `Bearer ${client.token}` },
     })
+    t.is(parseInt(res.headers.get('count') || ''), 1)
     const { ok, value } = await res.json()
 
     t.true(ok)


### PR DESCRIPTION
# Goals

You can't display a progress bar if you don't know what you're progressing toward :)

# Implementation

Essentially, use the count feature for posgrest-js that is used in web3.storage old
- add to count db.listUploads feature, which changes return type
- modify JSONResponse to actually allow passing headers
- update tests, though I wasn't able to run them cause mysterious connection refusal errors with my docker setup. but I think I got them passing here